### PR TITLE
Adds support for system_clock time_points of any duration.

### DIFF
--- a/examples/example1.cc
+++ b/examples/example1.cc
@@ -23,7 +23,7 @@ int main() {
   LoadTimeZone("America/Los_Angeles", &lax);
 
   // Time Programming Fundamentals @cppcon
-  const cctz::time_point tp = cctz::MakeTime(2015, 9, 22, 9, 0, 0, lax);
+  const auto tp = cctz::MakeTime(2015, 9, 22, 9, 0, 0, lax);
 
   cctz::TimeZone nyc;
   LoadTimeZone("America/New_York", &nyc);

--- a/examples/example2.cc
+++ b/examples/example2.cc
@@ -13,6 +13,7 @@
 //     See the License for the specific language governing permissions and
 //     limitations under the License.
 
+#include <chrono>
 #include <iostream>
 #include <string>
 
@@ -23,7 +24,7 @@ int main() {
 
   cctz::TimeZone lax;
   LoadTimeZone("America/Los_Angeles", &lax);
-  cctz::time_point tp;
+  std::chrono::system_clock::time_point tp;
   const bool ok = cctz::Parse("%Y-%m-%d %H:%M:%S", civil_string, lax, &tp);
   if (!ok) return -1;
 

--- a/examples/example3.cc
+++ b/examples/example3.cc
@@ -26,8 +26,7 @@ int main() {
   const cctz::Breakdown bd = cctz::BreakTime(now, lax);
 
   // First day of month, 6 months from now.
-  const cctz::time_point then =
-      cctz::MakeTime(bd.year, bd.month + 6, 1, 0, 0, 0, lax);
+  const auto then = cctz::MakeTime(bd.year, bd.month + 6, 1, 0, 0, 0, lax);
 
   std::cout << cctz::Format("Now: %F %T %z\n", now, lax);
   std::cout << cctz::Format("6mo: %F %T %z\n", then, lax);

--- a/examples/example4.cc
+++ b/examples/example4.cc
@@ -24,8 +24,7 @@ cctz::time_point<cctz::seconds64> FloorDay(cctz::time_point<D> tp,
   const cctz::Breakdown bd = cctz::BreakTime(tp, tz);
   const cctz::TimeInfo ti =
       cctz::MakeTimeInfo(bd.year, bd.month, bd.day, 0, 0, 0, tz);
-  if (ti.kind == cctz::TimeInfo::Kind::SKIPPED) return ti.trans;
-  return ti.pre;
+  return ti.kind == cctz::TimeInfo::Kind::SKIPPED ? ti.trans : ti.pre;
 }
 
 int main() {

--- a/examples/example4.cc
+++ b/examples/example4.cc
@@ -18,7 +18,9 @@
 
 #include "src/cctz.h"
 
-cctz::time_point FloorDay(cctz::time_point tp, cctz::TimeZone tz) {
+template <typename D>
+cctz::time_point<cctz::seconds64> FloorDay(cctz::time_point<D> tp,
+                                           cctz::TimeZone tz) {
   const cctz::Breakdown bd = cctz::BreakTime(tp, tz);
   const cctz::TimeInfo ti =
       cctz::MakeTimeInfo(bd.year, bd.month, bd.day, 0, 0, 0, tz);

--- a/examples/hello.cc
+++ b/examples/hello.cc
@@ -24,7 +24,7 @@ int main() {
   if (!cctz::LoadTimeZone("Australia/Sydney", &syd)) return -1;
 
   // Neil Armstrong first walks on the moon
-  const cctz::time_point tp1 = cctz::MakeTime(1969, 7, 21, 12, 56, 0, syd);
+  const auto tp1 = cctz::MakeTime(1969, 7, 21, 12, 56, 0, syd);
 
   const std::string s = cctz::Format("%F %T %z", tp1, syd);
   std::cout << s << "\n";
@@ -32,6 +32,6 @@ int main() {
   cctz::TimeZone nyc;
   cctz::LoadTimeZone("America/New_York", &nyc);
 
-  const cctz::time_point tp2 = cctz::MakeTime(1969, 7, 20, 22, 56, 0, nyc);
+  const auto tp2 = cctz::MakeTime(1969, 7, 20, 22, 56, 0, nyc);
   return tp2 == tp1 ? 0 : 1;
 }

--- a/src/cctz.h
+++ b/src/cctz.h
@@ -298,9 +298,9 @@ namespace cctz {
 
 namespace internal {
 // Floors tp to a second boundary. Optionally returns subseconds.
-template <typename D, typename Subseconds = D>
+template <typename D, typename Subseconds>
 inline time_point<seconds64> FloorSeconds(const time_point<D>& tp,
-                                          Subseconds* subseconds = nullptr) {
+                                          Subseconds* subseconds) {
   auto sec = std::chrono::time_point_cast<seconds64>(tp);
   auto sub = tp - sec;
   if (sub.count() < 0) {
@@ -311,9 +311,9 @@ inline time_point<seconds64> FloorSeconds(const time_point<D>& tp,
   return sec;
 }
 // Specialization for when tp is already second aligned.
-template <typename Subseconds = std::chrono::nanoseconds>
+template <typename Subseconds>
 inline time_point<seconds64> FloorSeconds(const time_point<seconds64>& sec,
-                                          Subseconds* subseconds = nullptr) {
+                                          Subseconds* subseconds) {
   if (subseconds) *subseconds = Subseconds::zero();
   return sec;
 }
@@ -322,7 +322,7 @@ inline time_point<seconds64> FloorSeconds(const time_point<seconds64>& sec,
 template <typename D>
 inline Breakdown BreakTime(const time_point<D>& tp, const TimeZone& tz) {
   Breakdown BreakTime(const time_point<seconds64>&, const TimeZone&);
-  return BreakTime(internal::FloorSeconds(tp), tz);
+  return BreakTime(internal::FloorSeconds(tp, static_cast<D*>(nullptr)), tz);
 }
 
 template <typename D>

--- a/src/cctz.h
+++ b/src/cctz.h
@@ -312,8 +312,8 @@ inline std::string Format(const std::string& format, const time_point<D>& tp,
 }
 
 template <typename D>
-bool Parse(const std::string& format, const std::string& input,
-           const TimeZone& tz, time_point<D>* tpp) {
+inline bool Parse(const std::string& format, const std::string& input,
+                  const TimeZone& tz, time_point<D>* tpp) {
   bool Parse(const std::string&, const std::string&, const TimeZone&,
              time_point<seconds64>*, std::chrono::nanoseconds*);
   time_point<seconds64> tp{};

--- a/src/cctz.h
+++ b/src/cctz.h
@@ -58,7 +58,7 @@ using seconds64 = std::chrono::duration<int64_t, std::chrono::seconds::period>;
 // as LoadTimeZone(). Note: strings like "PST" and "EDT" are not valid TZ
 // identifiers.
 //
-// Examples:
+// Example:
 //   cctz::TimeZone utc = cctz::UTCTimeZone();
 //   cctz::TimeZone loc = cctz::LocalTimeZone();
 //   cctz::TimeZone lax;
@@ -117,6 +117,11 @@ struct Breakdown {
 // Returns the civil time components (and some other data) for the given
 // absolute time in the given time zone. Accepts a system_clock time_point of
 // any duration.
+//
+// Example:
+//   const cctz::TimeZone tz = ...
+//   const auto tp = std::chrono::system_clock::now();
+//   const Breakdown bd = cctz::BreakTime(tp, tz);
 template <typename D>
 Breakdown BreakTime(const time_point<D>& tp, const TimeZone& tz);
 
@@ -125,6 +130,10 @@ Breakdown BreakTime(const time_point<D>& tp, const TimeZone& tz);
 // fields. If the given civil time refers to a time that is either skipped or
 // repeated (see the TimeInfo doc), then the as-if rule is followed and the
 // time_point according to the pre-transition offset is returned.
+//
+// Example:
+//   const cctz::TimeZone tz = ...
+//   const auto tp = cctz::MakeTime(2015, 1, 2, 3, 4, 5, tz);
 time_point<seconds64> MakeTime(int64_t year, int mon, int day,
                                int hour, int min, int sec,
                                const TimeZone& tz);
@@ -146,7 +155,7 @@ time_point<seconds64> MakeTime(int64_t year, int mon, int day,
 // returns times calculated using the pre-transition and post-transition UTC
 // offsets, plus the transition time itself.
 //
-// Examples:
+// Example:
 //   cctz::TimeZone lax;
 //   if (!cctz::LoadTimeZone("America/Los_Angeles", &lax)) { ... }
 //
@@ -197,6 +206,14 @@ struct TimeInfo {
 // the given TimeZone after normalizing the fields. NOTE: Prefer calling
 // the MakeTime() function unless you know that the default time_point
 // that it returns is not what you want.
+//
+// Example:
+//   // Calculates the first start of the day, given:
+//   //   int year, month, day;
+//   const cctz::TimeZone tz = ...
+//   const auto ti = cctz::MakeTimeInfo(year, month, day, 0, 0, 0, tz);
+//   const auto day_start =
+//       (ti.kind == cctz::TimeInfo::Kind::SKIPPED) ? ti.trans : ti.pre;
 TimeInfo MakeTimeInfo(int64_t year, int mon, int day, int hour,
                       int min, int sec, const TimeZone& tz);
 
@@ -222,7 +239,7 @@ TimeInfo MakeTimeInfo(int64_t year, int mon, int day, int hour,
 //   auto tp = cctz::MakeTime(2013, 1, 2, 3, 4, 5, lax);
 //
 //   std::string f = cctz::Format("%H:%M:%S", tp, lax);  // "03:04:05"
-//   f = cctz::Format("%H:%M:%E3S", tp, lax);  // "03:04:05.000"
+//   f = cctz::Format("%H:%M:%E3S", tp, lax);            // "03:04:05.000"
 template <typename D>
 std::string Format(const std::string& format, const time_point<D>& tp,
                    const TimeZone& tz);
@@ -261,6 +278,13 @@ std::string Format(const std::string& format, const time_point<D>& tp,
 //   "00.x" -> 00.x  // exact
 //
 // Errors are indicated by returning false.
+//
+// Example:
+//   const cctz::TimeZone tz = ...
+//   std::chrono::system_clock::time_point tp;
+//   if (cctz::Parse("%Y-%m-%d", "2015-10-09", tz, &tp)) {
+//     ...
+//   }
 template <typename D>
 bool Parse(const std::string& format, const std::string& input,
            const TimeZone& tz, time_point<D>* tpp);

--- a/src/cctz.h
+++ b/src/cctz.h
@@ -314,7 +314,7 @@ inline time_point<seconds64> FloorSeconds(const time_point<D>& tp,
 template <typename Subseconds = std::chrono::nanoseconds>
 inline time_point<seconds64> FloorSeconds(const time_point<seconds64>& sec,
                                           Subseconds* subseconds = nullptr) {
-  if (subseconds) *subseconds = Subseconds{};
+  if (subseconds) *subseconds = {};
   return sec;
 }
 }  // namespace internal

--- a/src/cctz.h
+++ b/src/cctz.h
@@ -314,7 +314,7 @@ inline time_point<seconds64> FloorSeconds(const time_point<D>& tp,
 template <typename Subseconds = std::chrono::nanoseconds>
 inline time_point<seconds64> FloorSeconds(const time_point<seconds64>& sec,
                                           Subseconds* subseconds = nullptr) {
-  if (subseconds) *subseconds = {};
+  if (subseconds) *subseconds = Subseconds::zero();
   return sec;
 }
 }  // namespace internal
@@ -330,7 +330,7 @@ inline std::string Format(const std::string& format, const time_point<D>& tp,
                           const TimeZone& tz) {
   std::string Format(const std::string&, const time_point<seconds64>&,
                      const std::chrono::nanoseconds&, const TimeZone&);
-  std::chrono::nanoseconds ns{};
+  std::chrono::nanoseconds ns{0};
   const auto sec = internal::FloorSeconds(tp, &ns);
   return Format(format, sec, ns, tz);
 }
@@ -341,7 +341,7 @@ inline bool Parse(const std::string& format, const std::string& input,
   bool Parse(const std::string&, const std::string&, const TimeZone&,
              time_point<seconds64>*, std::chrono::nanoseconds*);
   time_point<seconds64> tp{};
-  std::chrono::nanoseconds ns{};
+  std::chrono::nanoseconds ns{0};
   const bool b = Parse(format, input, tz, &tp, &ns);
   if (b) {
     *tpp = std::chrono::time_point_cast<D>(tp);

--- a/src/cctz.h
+++ b/src/cctz.h
@@ -106,7 +106,7 @@ struct Breakdown {
   int yearday;       // day of year [1:366]
 
   // Note: The following fields exist for backward compatibility with older
-  // APIs. Accessing these fields directly is a sign of misguided logic in the
+  // APIs. Accessing these fields directly is a sign of imprudent logic in the
   // calling code. Modern time-related code should only access this data
   // indirectly by way of cctz::Format().
   int offset;        // seconds east of UTC

--- a/src/cctz.h
+++ b/src/cctz.h
@@ -298,7 +298,7 @@ namespace cctz {
 
 namespace internal {
 // Floors tp to a second boundary. Optionally returns subseconds.
-template <typename D, typename Subseconds = std::chrono::nanoseconds>
+template <typename D, typename Subseconds = D>
 inline time_point<seconds64> FloorSeconds(const time_point<D>& tp,
                                           Subseconds* subseconds = nullptr) {
   auto sec = std::chrono::time_point_cast<seconds64>(tp);

--- a/src/cctz.h
+++ b/src/cctz.h
@@ -13,15 +13,16 @@
 //     See the License for the specific language governing permissions and
 //     limitations under the License.
 
-// CCTZ is a library for translating between absolute times (cctz::time_point)
-// and civil times (year, month, day, hour, minute, second) using the rules
-// defined by a time zone (cctz::TimeZone).
+// CCTZ is a library for translating between absolute times (represented as
+// std::chrono::time_points of the std::chrono::system_clock) and civil times
+// (year, month, day, hour, minute, second) using the rules defined by a time
+// zone (cctz::TimeZone).
 //
 // Example:
 //
 //   cctz::TimeZone lax;
 //   if (cctz::LoadTimeZone("America/Los_Angeles", &lax)) {
-//     cctz::time_point tp = cctz::MakeTime(2015, 1, 2, 3, 4, 5, lax);
+//     auto tp = cctz::MakeTime(2015, 1, 2, 3, 4, 5, lax);
 //     cctz::Breakdown bd = cctz::BreakTime(tp, lax);
 //     // bd.year == 2015
 //     // bd.month == 1
@@ -39,18 +40,22 @@
 
 namespace cctz {
 
-// Defines a time_point of the std::chrono::system_clock with a 128-bit
-// representation (but still with nanosecond resolution) to extend the range
-// beyond the +-292 years provided by the predefined types.
-using duration = std::chrono::duration<__int128, std::nano>;
-using time_point = std::chrono::time_point<std::chrono::system_clock, duration>;
+// All time point arguments and return values in this library are defined in
+// terms of the std::chrono::system_clock. System clock time points of any
+// duration are accepted as arguments, and system clock time points containing
+// 64-bits of seconds are returned from the MakeTime() and MakeTimeInfo()
+// functions. The following aliases are defined as a shorthand, not as new
+// concepts.
+template <typename D>
+using time_point = std::chrono::time_point<std::chrono::system_clock, D>;
+using seconds64 = std::chrono::duration<int64_t, std::chrono::seconds::period>;
 
 // cctz::TimeZone is an opaque, small, value-type class representing a
 // geo-political region within which particular rules are used for mapping
 // between absolute and civil times. TimeZones are named using the TZ
 // identifiers from the IANA Time Zone Database, such as "America/Los_Angeles"
-// or "Australia/Sydney".  TimeZones are created from factory functions such
-// as LoadTimeZone().  Note: strings like "PST" and "EDT" are not valid TZ
+// or "Australia/Sydney". TimeZones are created from factory functions such
+// as LoadTimeZone(). Note: strings like "PST" and "EDT" are not valid TZ
 // identifiers.
 //
 // Examples:
@@ -91,35 +96,42 @@ TimeZone LocalTimeZone();
 // intended to represent an instant in time. So, rather than passing a
 // Breakdown to a function, pass a time_point and a TimeZone.
 struct Breakdown {
-  int64_t year;        // year (e.g., 2013)
-  int month;           // month of year [1:12]
-  int day;             // day of month [1:31]
-  int hour;            // hour of day [0:23]
-  int minute;          // minute of hour [0:59]
-  int second;          // second of minute [0:59]
-  duration subsecond;  // [0s:1s)
-  int weekday;         // 1==Mon, ..., 7=Sun
-  int yearday;         // day of year [1:366]
-  int offset;          // seconds east of UTC
-  bool is_dst;         // is offset non-standard?
-  std::string abbr;    // time-zone abbreviation (e.g., "PST")
+  int64_t year;      // year (e.g., 2013)
+  int month;         // month of year [1:12]
+  int day;           // day of month [1:31]
+  int hour;          // hour of day [0:23]
+  int minute;        // minute of hour [0:59]
+  int second;        // second of minute [0:59]
+  int weekday;       // 1==Mon, ..., 7=Sun
+  int yearday;       // day of year [1:366]
+
+  // Note: The following fields exist for backward compatibility with older
+  // APIs. Accessing these fields directly is a sign of misguided logic in the
+  // calling code. Modern time-related code should only access this data
+  // indirectly by way of cctz::Format().
+  int offset;        // seconds east of UTC
+  bool is_dst;       // is offset non-standard?
+  std::string abbr;  // time-zone abbreviation (e.g., "PST")
 };
 
 // Returns the civil time components (and some other data) for the given
-// absolute time in the given time zone.
-Breakdown BreakTime(const time_point& tp, const TimeZone& tz);
+// absolute time in the given time zone. Accepts a system_clock time_point of
+// any duration.
+template <typename D>
+Breakdown BreakTime(const time_point<D>& tp, const TimeZone& tz);
 
-// Returns the cctz::time_point corresponding to the given civil time fields
-// in the given TimeZone after normalizing the fields. If the given civil time
-// refers to a time that is either skipped or repeated (see the TimeInfo doc),
-// then the as-if rule is followed and the time_point according to the
-// pre-transition offset is returned.
-time_point MakeTime(int64_t year, int mon, int day, int hour, int min, int sec,
-                    const TimeZone& tz);
+// Returns the system_clock time_point with 64-bits of seconds corresponding
+// to the given civil time fields in the given TimeZone after normalizing the
+// fields. If the given civil time refers to a time that is either skipped or
+// repeated (see the TimeInfo doc), then the as-if rule is followed and the
+// time_point according to the pre-transition offset is returned.
+time_point<seconds64> MakeTime(int64_t year, int mon, int day,
+                               int hour, int min, int sec,
+                               const TimeZone& tz);
 
 // A TimeInfo represents the conversion of year, month, day, hour, minute, and
 // second values, in a particular cctz::TimeZone, to a time instant, as
-// returned by MakeTimeInfo(). (Subseconds must be handled separately.)
+// returned by MakeTimeInfo().
 //
 // It is possible, though, for a caller to try to convert values that do not
 // represent an actual or unique instant in time (due to a shift in UTC offset
@@ -175,9 +187,9 @@ struct TimeInfo {
     SKIPPED,   // the civil time did not exist
     REPEATED,  // the civil time was ambiguous
   } kind;
-  time_point pre;  // Uses pre-transition offset
-  time_point trans;
-  time_point post;  // Uses post-transition offset
+  time_point<seconds64> pre;   // Uses the pre-transition offset
+  time_point<seconds64> trans;
+  time_point<seconds64> post;  // Uses the post-transition offset
   bool normalized;
 };
 
@@ -198,7 +210,7 @@ TimeInfo MakeTimeInfo(int64_t year, int mon, int day, int hour,
 //   - %E4Y - Four-character years (-999 ... -001, 0000, 0001 ... 9999)
 //
 // Note that %Y produces as many characters as it takes to fully render the
-// year.  A year outside of [-999:9999] when formatted with %E4Y will produce
+// year. A year outside of [-999:9999] when formatted with %E4Y will produce
 // more than four characters, just like %Y.
 //
 // Format strings should include %Ez so that the result uniquely identifies
@@ -207,11 +219,12 @@ TimeInfo MakeTimeInfo(int64_t year, int mon, int day, int hour,
 // Example:
 //   cctz::TimeZone lax;
 //   if (!cctz::LoadTimeZone("America/Los_Angeles", &lax)) { ... }
-//   cctz::time_point tp = cctz::MakeTime(2013, 1, 2, 3, 4, 5, lax);
+//   auto tp = cctz::MakeTime(2013, 1, 2, 3, 4, 5, lax);
 //
 //   std::string f = cctz::Format("%H:%M:%S", tp, lax);  // "03:04:05"
 //   f = cctz::Format("%H:%M:%E3S", tp, lax);  // "03:04:05.000"
-std::string Format(const std::string& format, const time_point& tp,
+template <typename D>
+std::string Format(const std::string& format, const time_point<D>& tp,
                    const TimeZone& tz);
 
 // Parses an input string according to the provided format string and returns
@@ -232,9 +245,8 @@ std::string Format(const std::string& format, const time_point& tp,
 // fully-specified date/time strings that include a UTC offset (%z/%Ez).
 //
 // Note also that Parse() only heeds the fields year, month, day, hour,
-// minute, (fractional) second, and UTC offset.  Other fields, like
-// weekday (%a or %A), while parsed for syntactic validity, are ignored
-// in the conversion.
+// minute, (fractional) second, and UTC offset. Other fields, like weekday (%a
+// or %A), while parsed for syntactic validity, are ignored in the conversion.
 //
 // Date and time fields that are out-of-range will be treated as errors rather
 // than normalizing them like cctz::MakeTime() does. For example, it is an
@@ -249,8 +261,70 @@ std::string Format(const std::string& format, const time_point& tp,
 //   "00.x" -> 00.x  // exact
 //
 // Errors are indicated by returning false.
+template <typename D>
 bool Parse(const std::string& format, const std::string& input,
-           const TimeZone& tz, time_point* tpp);
+           const TimeZone& tz, time_point<D>* tpp);
+
+}  // namespace cctz
+
+//
+// IMPLEMENTATION DETAILS
+//
+namespace cctz {
+
+namespace internal {
+// Floors tp to a second boundary. Optionally returns subseconds.
+template <typename D, typename Subseconds = std::chrono::nanoseconds>
+inline time_point<seconds64> FloorSeconds(const time_point<D>& tp,
+                                          Subseconds* subseconds = nullptr) {
+  auto sec = std::chrono::time_point_cast<seconds64>(tp);
+  auto sub = tp - sec;
+  if (sub.count() < 0) {
+    sec -= seconds64(1);
+    sub += seconds64(1);
+  }
+  if (subseconds) *subseconds = std::chrono::duration_cast<Subseconds>(sub);
+  return sec;
+}
+// Specialization for when tp is already second aligned.
+template <typename Subseconds = std::chrono::nanoseconds>
+inline time_point<seconds64> FloorSeconds(const time_point<seconds64>& sec,
+                                          Subseconds* subseconds = nullptr) {
+  if (subseconds) *subseconds = Subseconds{};
+  return sec;
+}
+}  // namespace internal
+
+template <typename D>
+inline Breakdown BreakTime(const time_point<D>& tp, const TimeZone& tz) {
+  Breakdown BreakTime(const time_point<seconds64>&, const TimeZone&);
+  return BreakTime(internal::FloorSeconds(tp), tz);
+}
+
+template <typename D>
+inline std::string Format(const std::string& format, const time_point<D>& tp,
+                          const TimeZone& tz) {
+  std::string Format(const std::string&, const time_point<seconds64>&,
+                     const std::chrono::nanoseconds&, const TimeZone&);
+  std::chrono::nanoseconds ns{};
+  const auto sec = internal::FloorSeconds(tp, &ns);
+  return Format(format, sec, ns, tz);
+}
+
+template <typename D>
+bool Parse(const std::string& format, const std::string& input,
+           const TimeZone& tz, time_point<D>* tpp) {
+  bool Parse(const std::string&, const std::string&, const TimeZone&,
+             time_point<seconds64>*, std::chrono::nanoseconds*);
+  time_point<seconds64> tp{};
+  std::chrono::nanoseconds ns{};
+  const bool b = Parse(format, input, tz, &tp, &ns);
+  if (b) {
+    *tpp = std::chrono::time_point_cast<D>(tp);
+    *tpp += std::chrono::duration_cast<D>(ns);
+  }
+  return b;
+}
 
 }  // namespace cctz
 

--- a/src/cctz_cnv.cc
+++ b/src/cctz_cnv.cc
@@ -45,13 +45,13 @@ bool LoadTimeZone(const std::string& name, TimeZone* tz) {
   return TimeZone::Impl::LoadTimeZone(name, tz);
 }
 
-Breakdown BreakTime(const time_point& tp, const TimeZone& tz) {
+Breakdown BreakTime(const time_point<seconds64>& tp, const TimeZone& tz) {
   return TimeZone::Impl::get(tz).BreakTime(tp);
 }
 
-time_point MakeTime(int64_t year, int mon, int day,
-                    int hour, int min, int sec,
-                    const TimeZone& tz) {
+time_point<seconds64> MakeTime(int64_t year, int mon, int day,
+                               int hour, int min, int sec,
+                               const TimeZone& tz) {
   return MakeTimeInfo(year, mon, day, hour, min, sec, tz).pre;
 }
 

--- a/src/cctz_fmt.cc
+++ b/src/cctz_fmt.cc
@@ -656,7 +656,7 @@ bool Parse(const std::string& format, const std::string& input,
   // If we saw %s then we ignore anything else and return that time.
   if (saw_percent_s) {
     *tpp = FromUnixSeconds(percent_s_time);
-    *ns = {};
+    *ns = std::chrono::nanoseconds::zero();
     return true;
   }
 
@@ -674,7 +674,7 @@ bool Parse(const std::string& format, const std::string& input,
   if (tm.tm_sec == 60) {
     tm.tm_sec -= 1;
     offset -= 1;
-    subseconds = {};
+    subseconds = std::chrono::nanoseconds::zero();
   }
 
   int64_t year = tm.tm_year;

--- a/src/cctz_if.h
+++ b/src/cctz_if.h
@@ -32,7 +32,7 @@ class TimeZoneIf {
 
   virtual ~TimeZoneIf() {}
 
-  virtual Breakdown BreakTime(const time_point& tp) const = 0;
+  virtual Breakdown BreakTime(const time_point<seconds64>& tp) const = 0;
   virtual TimeInfo MakeTimeInfo(int64_t year, int mon, int day,
                                 int hour, int min, int sec) const = 0;
 
@@ -40,18 +40,18 @@ class TimeZoneIf {
   TimeZoneIf() {}
 };
 
-// Convert a time_point to a count of seconds since the Unix epoch.
-inline int64_t ToUnixSeconds(const time_point& tp) {
-  return std::chrono::duration_cast<std::chrono::duration<int64_t>>(
-             tp - std::chrono::system_clock::from_time_t(0))
+// Converts tp to a count of seconds since the Unix epoch.
+inline int64_t ToUnixSeconds(const time_point<seconds64>& tp) {
+  return (tp - std::chrono::time_point_cast<seconds64>(
+                   std::chrono::system_clock::from_time_t(0)))
       .count();
 }
 
-// Convert a count of seconds since the Unix epoch to a time_point.
-inline time_point FromUnixSeconds(int64_t t) {
-  return std::chrono::time_point_cast<time_point::duration>(
+// Converts a count of seconds since the Unix epoch to a time_point<seconds64>.
+inline time_point<seconds64> FromUnixSeconds(int64_t t) {
+  return std::chrono::time_point_cast<seconds64>(
              std::chrono::system_clock::from_time_t(0)) +
-         std::chrono::seconds(t);
+         seconds64(t);
 }
 
 }  // namespace cctz

--- a/src/cctz_impl.cc
+++ b/src/cctz_impl.cc
@@ -99,7 +99,7 @@ const TimeZone::Impl& TimeZone::Impl::get(const TimeZone& tz) {
 
 TimeZone::Impl::Impl(const std::string& name) : name_(name) {}
 
-Breakdown TimeZone::Impl::BreakTime(const time_point& tp) const {
+Breakdown TimeZone::Impl::BreakTime(const time_point<seconds64>& tp) const {
   return zone_->BreakTime(tp);
 }
 

--- a/src/cctz_impl.h
+++ b/src/cctz_impl.h
@@ -35,7 +35,7 @@ class TimeZone::Impl {
   static const TimeZone::Impl& get(const TimeZone& tz);
 
   // Breaks a time_point down to civil-time components in this time zone.
-  Breakdown BreakTime(const time_point& tp) const;
+  Breakdown BreakTime(const time_point<seconds64>& tp) const;
 
   // Converts the civil-time components in this time zone into a time_point.
   // That is, the opposite of BreakTime(). The requested civil time may be

--- a/src/cctz_info.h
+++ b/src/cctz_info.h
@@ -96,7 +96,7 @@ class TimeZoneInfo : public TimeZoneIf {
   bool Load(const std::string& name);
 
   // TimeZoneIf implementations.
-  Breakdown BreakTime(const time_point& tp) const override;
+  Breakdown BreakTime(const time_point<seconds64>& tp) const override;
   TimeInfo MakeTimeInfo(int64_t year, int mon, int day,
                         int hour, int min, int sec) const override;
 
@@ -121,8 +121,7 @@ class TimeZoneInfo : public TimeZoneIf {
   bool Load(const std::string& name, FILE* fp);
 
   // Helpers for BreakTime() and MakeTimeInfo() respectively.
-  Breakdown LocalTime(int64_t unix_time, duration subsecond,
-                      const TransitionType& tt) const;
+  Breakdown LocalTime(int64_t unix_time, const TransitionType& tt) const;
   TimeInfo TimeLocal(int64_t year, int mon, int day,
                      int hour, int min, int sec, __int128 offset) const;
 

--- a/src/cctz_libc.cc
+++ b/src/cctz_libc.cc
@@ -30,14 +30,9 @@ TimeZoneLibC::TimeZoneLibC(const std::string& name) {
   }
 }
 
-Breakdown TimeZoneLibC::BreakTime(const time_point& tp) const {
+Breakdown TimeZoneLibC::BreakTime(const time_point<seconds64>& tp) const {
   Breakdown bd;
   std::time_t t = ToUnixSeconds(tp);
-  duration subsecond = tp - FromUnixSeconds(t);
-  if (subsecond < duration::zero()) {
-    t -= 1;
-    subsecond += std::chrono::seconds(1);
-  }
   std::tm tm;
   if (local_) {
     localtime_r(&t, &tm);
@@ -53,7 +48,6 @@ Breakdown TimeZoneLibC::BreakTime(const time_point& tp) const {
   bd.hour = tm.tm_hour;
   bd.minute = tm.tm_min;
   bd.second = tm.tm_sec;
-  bd.subsecond = subsecond;
   bd.weekday = (tm.tm_wday ? tm.tm_wday : 7);
   bd.yearday = tm.tm_yday + 1;
   bd.is_dst = tm.tm_isdst;

--- a/src/cctz_libc.h
+++ b/src/cctz_libc.h
@@ -29,7 +29,7 @@ class TimeZoneLibC : public TimeZoneIf {
   explicit TimeZoneLibC(const std::string& name);
 
   // TimeZoneIf implementations.
-  Breakdown BreakTime(const time_point& tp) const override;
+  Breakdown BreakTime(const time_point<seconds64>& tp) const override;
   TimeInfo MakeTimeInfo(int64_t year, int mon, int day,
                         int hour, int min, int sec) const override;
 

--- a/test/cnv_test.cc
+++ b/test/cnv_test.cc
@@ -688,6 +688,14 @@ TEST(TimeZone, Failures) {
             MakeTime(1970, 1, 1, 0, 0, 0, tz));  // UTC
 }
 
+TEST(StdChronoTimePoint, TimeTAlignment) {
+  // Ensures that the Unix epoch and the system clock epoch are an integral
+  // number of seconds apart. This simplifies conversions to/from time_t.
+  using TP = std::chrono::system_clock::time_point;
+  auto diff = TP() - std::chrono::system_clock::from_time_t(0);
+  EXPECT_EQ(TP::duration::zero(), diff % std::chrono::seconds(1));
+}
+
 TEST(BreakTime, LocalTimeInUTC) {
   const Breakdown bd = BreakTime(system_clock::from_time_t(0), UTCTimeZone());
   ExpectTime(bd, 1970, 1, 1, 0, 0, 0, 0, false, "UTC");
@@ -725,7 +733,7 @@ TEST(BreakTime, LocalTimeInSydney) {
 
 TEST(MakeTime, Normalization) {
   const TimeZone tz = LoadZone("America/New_York");
-  const time_point tp = MakeTime(2009, 2, 13, 18, 31, 30, tz);
+  const auto tp = MakeTime(2009, 2, 13, 18, 31, 30, tz);
   EXPECT_EQ(system_clock::from_time_t(1234567890), tp);
 
   // Now requests for the same time_point but with out-of-range fields.
@@ -740,7 +748,7 @@ TEST(TimeZoneEdgeCase, AmericaNewYork) {
   const TimeZone tz = LoadZone("America/New_York");
 
   // Spring 1:59:59 -> 3:00:00
-  time_point tp = MakeTime(2013, 3, 10, 1, 59, 59, tz);
+  auto tp = MakeTime(2013, 3, 10, 1, 59, 59, tz);
   Breakdown bd = BreakTime(tp, tz);
   ExpectTime(bd, 2013, 3, 10, 1, 59, 59, -5 * 3600, false, "EST");
   tp += std::chrono::seconds(1);
@@ -760,7 +768,7 @@ TEST(TimeZoneEdgeCase, AmericaLosAngeles) {
   const TimeZone tz = LoadZone("America/Los_Angeles");
 
   // Spring 1:59:59 -> 3:00:00
-  time_point tp = MakeTime(2013, 3, 10, 1, 59, 59, tz);
+  auto tp = MakeTime(2013, 3, 10, 1, 59, 59, tz);
   Breakdown bd = BreakTime(tp, tz);
   ExpectTime(bd, 2013, 3, 10, 1, 59, 59, -8 * 3600, false, "PST");
   tp += std::chrono::seconds(1);
@@ -780,7 +788,7 @@ TEST(TimeZoneEdgeCase, ArizonaNoTransition) {
   const TimeZone tz = LoadZone("America/Phoenix");
 
   // No transition in Spring.
-  time_point tp = MakeTime(2013, 3, 10, 1, 59, 59, tz);
+  auto tp = MakeTime(2013, 3, 10, 1, 59, 59, tz);
   Breakdown bd = BreakTime(tp, tz);
   ExpectTime(bd, 2013, 3, 10, 1, 59, 59, -7 * 3600, false, "MST");
   tp += std::chrono::seconds(1);
@@ -803,7 +811,7 @@ TEST(TimeZoneEdgeCase, AsiaKathmandu) {
   //
   //   504901799 == Tue, 31 Dec 1985 23:59:59 +0530 (IST)
   //   504901800 == Wed,  1 Jan 1986 00:15:00 +0545 (NPT)
-  time_point tp = MakeTime(1985, 12, 31, 23, 59, 59, tz);
+  auto tp = MakeTime(1985, 12, 31, 23, 59, 59, tz);
   Breakdown bd = BreakTime(tp, tz);
   ExpectTime(bd, 1985, 12, 31, 23, 59, 59, 5.5 * 3600, false, "IST");
   tp += std::chrono::seconds(1);
@@ -818,7 +826,7 @@ TEST(TimeZoneEdgeCase, PacificChatham) {
   //
   //   1365256799 == Sun,  7 Apr 2013 03:44:59 +1345 (CHADT)
   //   1365256800 == Sun,  7 Apr 2013 02:45:00 +1245 (CHAST)
-  time_point tp = MakeTime(2013, 4, 7, 3, 44, 59, tz);
+  auto tp = MakeTime(2013, 4, 7, 3, 44, 59, tz);
   Breakdown bd = BreakTime(tp, tz);
   ExpectTime(bd, 2013, 4, 7, 3, 44, 59, 13.75 * 3600, true, "CHADT");
   tp += std::chrono::seconds(1);
@@ -842,7 +850,7 @@ TEST(TimeZoneEdgeCase, AustraliaLordHowe) {
   //
   //   1365260399 == Sun,  7 Apr 2013 01:59:59 +1100 (LHDT)
   //   1365260400 == Sun,  7 Apr 2013 01:30:00 +1030 (LHST)
-  time_point tp = MakeTime(2013, 4, 7, 1, 59, 59, tz);
+  auto tp = MakeTime(2013, 4, 7, 1, 59, 59, tz);
   Breakdown bd = BreakTime(tp, tz);
   ExpectTime(bd, 2013, 4, 7, 1, 59, 59, 11 * 3600, true, "LHDT");
   tp += std::chrono::seconds(1);
@@ -870,7 +878,7 @@ TEST(TimeZoneEdgeCase, PacificApia) {
   //
   //   1325239199 == Thu, 29 Dec 2011 23:59:59 -1000 (SDT)
   //   1325239200 == Sat, 31 Dec 2011 00:00:00 +1400 (WSDT)
-  time_point tp = MakeTime(2011, 12, 29, 23, 59, 59, tz);
+  auto tp = MakeTime(2011, 12, 29, 23, 59, 59, tz);
   Breakdown bd = BreakTime(tp, tz);
   ExpectTime(bd, 2011, 12, 29, 23, 59, 59, -10 * 3600, true, "SDT");
   EXPECT_EQ(363, bd.yearday);
@@ -887,7 +895,7 @@ TEST(TimeZoneEdgeCase, AfricaCairo) {
   //
   //   1400191199 == Thu, 15 May 2014 23:59:59 +0200 (EET)
   //   1400191200 == Fri, 16 May 2014 01:00:00 +0300 (EEST)
-  time_point tp = MakeTime(2014, 5, 15, 23, 59, 59, tz);
+  auto tp = MakeTime(2014, 5, 15, 23, 59, 59, tz);
   Breakdown bd = BreakTime(tp, tz);
   ExpectTime(bd, 2014, 5, 15, 23, 59, 59, 2 * 3600, false, "EET");
   tp += std::chrono::seconds(1);
@@ -902,7 +910,7 @@ TEST(TimeZoneEdgeCase, AfricaMonrovia) {
   //
   //   73529069 == Sun, 30 Apr 1972 23:59:59 -0044 (LRT)
   //   73529070 == Mon,  1 May 1972 00:44:30 +0000 (GMT)
-  time_point tp = MakeTime(1972, 4, 30, 23, 59, 59, tz);
+  auto tp = MakeTime(1972, 4, 30, 23, 59, 59, tz);
   Breakdown bd = BreakTime(tp, tz);
   ExpectTime(bd, 1972, 4, 30, 23, 59, 59, -44.5 * 60, false, "LRT");
   tp += std::chrono::seconds(1);
@@ -919,7 +927,7 @@ TEST(TimeZoneEdgeCase, AmericaJamaica) {
   const TimeZone tz = LoadZone("America/Jamaica");
 
   // Before the first transition.
-  time_point tp = MakeTime(1889, 12, 31, 0, 0, 0, tz);
+  auto tp = MakeTime(1889, 12, 31, 0, 0, 0, tz);
   Breakdown bd = BreakTime(tp, tz);
   ExpectTime(bd, 1889, 12, 31, 0, 0, 0, -18431, false, bd.abbr);
 
@@ -954,7 +962,7 @@ TEST(TimeZoneEdgeCase, WET) {
   const TimeZone tz = LoadZone("WET");
 
   // Before the first transition.
-  time_point tp = MakeTime(1977, 1, 1, 0, 0, 0, tz);
+  auto tp = MakeTime(1977, 1, 1, 0, 0, 0, tz);
   Breakdown bd = BreakTime(tp, tz);
   ExpectTime(bd, 1977, 1, 1, 0, 0, 0, 0, false, "WET");
 
@@ -993,7 +1001,7 @@ TEST(TimeZoneEdgeCase, WET) {
 
 TEST(TimeZoneEdgeCase, FixedOffsets) {
   const TimeZone gmtp5 = LoadZone("Etc/GMT+5");
-  time_point tp = MakeTime(1970, 1, 1, 0, 0, 0, gmtp5);
+  auto tp = MakeTime(1970, 1, 1, 0, 0, 0, gmtp5);
   Breakdown bd = BreakTime(tp, gmtp5);
   ExpectTime(bd, 1970, 1, 1, 0, 0, 0, -5 * 3600, false, "GMT+5");
   EXPECT_EQ(system_clock::from_time_t(5 * 3600), tp);
@@ -1008,7 +1016,7 @@ TEST(TimeZoneEdgeCase, FixedOffsets) {
 TEST(TimeZoneEdgeCase, NegativeYear) {
   // Tests transition from year 0 (aka 1BCE) to year -1.
   const TimeZone tz = UTCTimeZone();
-  time_point tp = MakeTime(0, 1, 1, 0, 0, 0, tz);
+  auto tp = MakeTime(0, 1, 1, 0, 0, 0, tz);
   Breakdown bd = BreakTime(tp, tz);
   ExpectTime(bd, 0, 1, 1, 0, 0, 0, 0 * 3600, false, "UTC");
   EXPECT_EQ(6, bd.weekday);
@@ -1025,7 +1033,7 @@ TEST(TimeZoneEdgeCase, UTC32bitLimit) {
   //
   //   2147483647 == Tue, 19 Jan 2038 03:14:07 +0000 (UTC)
   //   2147483648 == Tue, 19 Jan 2038 03:14:08 +0000 (UTC)
-  time_point tp = MakeTime(2038, 1, 19, 3, 14, 7, tz);
+  auto tp = MakeTime(2038, 1, 19, 3, 14, 7, tz);
   Breakdown bd = BreakTime(tp, tz);
   ExpectTime(bd, 2038, 1, 19, 3, 14, 7, 0 * 3600, false, "UTC");
   tp += std::chrono::seconds(1);
@@ -1040,7 +1048,7 @@ TEST(TimeZoneEdgeCase, UTC5DigitYear) {
   //
   //   253402300799 == Fri, 31 Dec 9999 23:59:59 +0000 (UTC)
   //   253402300800 == Sat,  1 Jan 1000 00:00:00 +0000 (UTC)
-  time_point tp = MakeTime(9999, 12, 31, 23, 59, 59, tz);
+  auto tp = MakeTime(9999, 12, 31, 23, 59, 59, tz);
   Breakdown bd = BreakTime(tp, tz);
   ExpectTime(bd, 9999, 12, 31, 23, 59, 59, 0 * 3600, false, "UTC");
   tp += std::chrono::seconds(1);

--- a/test/cnv_test.cc
+++ b/test/cnv_test.cc
@@ -696,6 +696,28 @@ TEST(StdChronoTimePoint, TimeTAlignment) {
   EXPECT_EQ(TP::duration::zero(), diff % std::chrono::seconds(1));
 }
 
+TEST(BreakTime, TimePointResolution) {
+  using std::chrono::time_point_cast;
+  const TimeZone utc = UTCTimeZone();
+  const auto t0 = system_clock::from_time_t(0);
+  Breakdown bd{};
+
+  bd = BreakTime(time_point_cast<std::chrono::nanoseconds>(t0), utc);
+  ExpectTime(bd, 1970, 1, 1, 0, 0, 0, 0, false, "UTC");
+  bd = BreakTime(time_point_cast<std::chrono::microseconds>(t0), utc);
+  ExpectTime(bd, 1970, 1, 1, 0, 0, 0, 0, false, "UTC");
+  bd = BreakTime(time_point_cast<std::chrono::milliseconds>(t0), utc);
+  ExpectTime(bd, 1970, 1, 1, 0, 0, 0, 0, false, "UTC");
+  bd = BreakTime(time_point_cast<std::chrono::seconds>(t0), utc);
+  ExpectTime(bd, 1970, 1, 1, 0, 0, 0, 0, false, "UTC");
+  bd = BreakTime(time_point_cast<seconds64>(t0), utc);
+  ExpectTime(bd, 1970, 1, 1, 0, 0, 0, 0, false, "UTC");
+  bd = BreakTime(time_point_cast<std::chrono::minutes>(t0), utc);
+  ExpectTime(bd, 1970, 1, 1, 0, 0, 0, 0, false, "UTC");
+  bd = BreakTime(time_point_cast<std::chrono::hours>(t0), utc);
+  ExpectTime(bd, 1970, 1, 1, 0, 0, 0, 0, false, "UTC");
+}
+
 TEST(BreakTime, LocalTimeInUTC) {
   const Breakdown bd = BreakTime(system_clock::from_time_t(0), UTCTimeZone());
   ExpectTime(bd, 1970, 1, 1, 0, 0, 0, 0, false, "UTC");
@@ -729,6 +751,31 @@ TEST(BreakTime, LocalTimeInSydney) {
   const Breakdown bd = BreakTime(system_clock::from_time_t(90), tz);
   ExpectTime(bd, 1970, 1, 1, 10, 1, 30, 10 * 60 * 60, false, "AEST");
   EXPECT_EQ(4, bd.weekday);  // Thursday
+}
+
+TEST(MakeTime, TimePointResolution) {
+  const TimeZone utc = UTCTimeZone();
+  const time_point<std::chrono::nanoseconds> tp_ns = MakeTime(2015, 1, 2, 3, 4, 5, utc);
+  EXPECT_EQ("04:05", Format("%M:%E*S", tp_ns, utc));
+  const time_point<std::chrono::microseconds> tp_us = MakeTime(2015, 1, 2, 3, 4, 5, utc);
+  EXPECT_EQ("04:05", Format("%M:%E*S", tp_us, utc));
+  const time_point<std::chrono::milliseconds> tp_ms = MakeTime(2015, 1, 2, 3, 4, 5, utc);
+  EXPECT_EQ("04:05", Format("%M:%E*S", tp_ms, utc));
+  const time_point<std::chrono::seconds> tp_s = MakeTime(2015, 1, 2, 3, 4, 5, utc);
+  EXPECT_EQ("04:05", Format("%M:%E*S", tp_s, utc));
+  const time_point<seconds64> tp_s64 = MakeTime(2015, 1, 2, 3, 4, 5, utc);
+  EXPECT_EQ("04:05", Format("%M:%E*S", tp_s64, utc));
+
+  // These next two require time_point_cast because the conversion from a
+  // resolution of seconds (the return value of MakeTime()) to a coarser
+  // resolution requires an explicit cast.
+  using std::chrono::time_point_cast;
+  const time_point<std::chrono::minutes> tp_m =
+      time_point_cast<std::chrono::minutes>(MakeTime(2015, 1, 2, 3, 4, 5, utc));
+  EXPECT_EQ("04:00", Format("%M:%E*S", tp_m, utc));
+  const time_point<std::chrono::hours> tp_h =
+      time_point_cast<std::chrono::hours>(MakeTime(2015, 1, 2, 3, 4, 5, utc));
+  EXPECT_EQ("00:00", Format("%M:%E*S", tp_h, utc));
 }
 
 TEST(MakeTime, Normalization) {

--- a/test/fmt_test.cc
+++ b/test/fmt_test.cc
@@ -76,7 +76,7 @@ void TestFormatSpecifier(time_point<D> tp, TimeZone tz, const std::string& fmt,
 
 TEST(Format, Basics) {
   TimeZone tz = UTCTimeZone();
-  auto tp = system_clock::from_time_t(0);
+  time_point<std::chrono::nanoseconds> tp = system_clock::from_time_t(0);
 
   // Starts with a couple basic edge cases.
   EXPECT_EQ("", Format("", tp, tz));
@@ -206,7 +206,7 @@ TEST(Format, Escaping) {
 
 TEST(Format, ExtendedSeconds) {
   const TimeZone tz = UTCTimeZone();
-  auto tp = system_clock::from_time_t(0);
+  time_point<std::chrono::nanoseconds> tp = system_clock::from_time_t(0);
   tp += hours(3) + minutes(4) + seconds(5);
   tp += milliseconds(6) + microseconds(7) + nanoseconds(8);
 
@@ -726,7 +726,7 @@ TEST(Parse, ExtendedSeconds) {
   // Here is a "%E*S" case we got wrong for a while.  The fractional
   // part of the first instant is less than 2^31 and was correctly
   // parsed, while the second (and any subsecond field >=2^31) failed.
-  auto tp = system_clock::from_time_t(0);
+  time_point<std::chrono::nanoseconds> tp = system_clock::from_time_t(0);
   EXPECT_TRUE(Parse("%E*S", "0.2147483647", tz, &tp));
   EXPECT_EQ(system_clock::from_time_t(0) + nanoseconds(214748364), tp);
   tp = system_clock::from_time_t(0);

--- a/test/fmt_test.cc
+++ b/test/fmt_test.cc
@@ -74,6 +74,29 @@ void TestFormatSpecifier(time_point<D> tp, TimeZone tz, const std::string& fmt,
 // Testing Format()
 //
 
+TEST(Format, TimePointResolution) {
+  using std::chrono::time_point_cast;
+  const char kFmt[] = "%H:%M:%E*S";
+  const TimeZone utc = UTCTimeZone();
+  const time_point<std::chrono::nanoseconds> t0 =
+      system_clock::from_time_t(1420167845) + std::chrono::milliseconds(123) +
+      std::chrono::microseconds(456) + std::chrono::nanoseconds(789);
+  EXPECT_EQ("03:04:05.123456789",
+            Format(kFmt, time_point_cast<std::chrono::nanoseconds>(t0), utc));
+  EXPECT_EQ("03:04:05.123456",
+            Format(kFmt, time_point_cast<std::chrono::microseconds>(t0), utc));
+  EXPECT_EQ("03:04:05.123",
+            Format(kFmt, time_point_cast<std::chrono::milliseconds>(t0), utc));
+  EXPECT_EQ("03:04:05",
+            Format(kFmt, time_point_cast<std::chrono::seconds>(t0), utc));
+  EXPECT_EQ("03:04:05",
+            Format(kFmt, time_point_cast<seconds64>(t0), utc));
+  EXPECT_EQ("03:04:00",
+            Format(kFmt, time_point_cast<std::chrono::minutes>(t0), utc));
+  EXPECT_EQ("03:00:00",
+            Format(kFmt, time_point_cast<std::chrono::hours>(t0), utc));
+}
+
 TEST(Format, Basics) {
   TimeZone tz = UTCTimeZone();
   time_point<std::chrono::nanoseconds> tp = system_clock::from_time_t(0);
@@ -359,6 +382,48 @@ TEST(Format, RFC1123Format) {  // locale specific
 //
 // Testing Parse()
 //
+
+TEST(Parse, TimePointResolution) {
+  using std::chrono::time_point_cast;
+  const char kFmt[] = "%H:%M:%E*S";
+  const TimeZone utc = UTCTimeZone();
+
+  time_point<std::chrono::nanoseconds> tp_ns;
+  EXPECT_TRUE(Parse(kFmt, "03:04:05.123456789", utc, &tp_ns));
+  EXPECT_EQ("03:04:05.123456789", Format(kFmt, tp_ns, utc));
+  EXPECT_TRUE(Parse(kFmt, "03:04:05.123456", utc, &tp_ns));
+  EXPECT_EQ("03:04:05.123456", Format(kFmt, tp_ns, utc));
+
+  time_point<std::chrono::microseconds> tp_us;
+  EXPECT_TRUE(Parse(kFmt, "03:04:05.123456789", utc, &tp_us));
+  EXPECT_EQ("03:04:05.123456", Format(kFmt, tp_us, utc));
+  EXPECT_TRUE(Parse(kFmt, "03:04:05.123456", utc, &tp_us));
+  EXPECT_EQ("03:04:05.123456", Format(kFmt, tp_us, utc));
+  EXPECT_TRUE(Parse(kFmt, "03:04:05.123", utc, &tp_us));
+  EXPECT_EQ("03:04:05.123", Format(kFmt, tp_us, utc));
+
+  time_point<std::chrono::milliseconds> tp_ms;
+  EXPECT_TRUE(Parse(kFmt, "03:04:05.123456", utc, &tp_ms));
+  EXPECT_EQ("03:04:05.123", Format(kFmt, tp_ms, utc));
+  EXPECT_TRUE(Parse(kFmt, "03:04:05.123", utc, &tp_ms));
+  EXPECT_EQ("03:04:05.123", Format(kFmt, tp_ms, utc));
+  EXPECT_TRUE(Parse(kFmt, "03:04:05", utc, &tp_ms));
+  EXPECT_EQ("03:04:05", Format(kFmt, tp_ms, utc));
+
+  time_point<std::chrono::seconds> tp_s;
+  EXPECT_TRUE(Parse(kFmt, "03:04:05.123", utc, &tp_s));
+  EXPECT_EQ("03:04:05", Format(kFmt, tp_s, utc));
+  EXPECT_TRUE(Parse(kFmt, "03:04:05", utc, &tp_s));
+  EXPECT_EQ("03:04:05", Format(kFmt, tp_s, utc));
+
+  time_point<std::chrono::minutes> tp_m;
+  EXPECT_TRUE(Parse(kFmt, "03:04:05", utc, &tp_m));
+  EXPECT_EQ("03:04:00", Format(kFmt, tp_m, utc));
+
+  time_point<std::chrono::hours> tp_h;
+  EXPECT_TRUE(Parse(kFmt, "03:04:05", utc, &tp_h));
+  EXPECT_EQ("03:00:00", Format(kFmt, tp_h, utc));
+}
 
 TEST(Parse, Basics) {
   TimeZone tz = UTCTimeZone();


### PR DESCRIPTION
This change removes the need for a 128-bit count of nanoseconds that was
defined by the cctz::time_point type. Instead, cctz functions that
accept time_points can accept any time_point of the form:

  `std::chrono::time_point<std::chrono::system_clock, D>`

And functions that produce time points, such as MakeTime() and
`MakeTimeInfo()` now return system_clock time points that are a 64-bit
count of seconds.

There is still a "cctz::time_point" alias defined, but that is simply a
shorthand, and it is not defining a new concept.

The advantages of this change are:
- No unnecessary "cctz::time_point" concept.
- No required use of int128 in the interface.
- All time points that users already have are now accepted.
- No need to pass 128-bits of data where the low 64-bits are all zeros.

Misc other changes:
- Added warning comment about Breakdown's offset, is_dst, and abbr
  fields.
- Removed the subseconds field from Breakdown. We discovered that it is
  rarely needed (and when used, it's often used incorrectly). We can add
  it back later if/when needed.