### PR TITLE
Add googletest -inl headers to BUILD

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -4,6 +4,7 @@ cc_library(
     srcs = glob(
         [
             "google*/src/*.cc",
+            "google*/src/*-inl.h",
         ],
         exclude = glob([
             "google*/src/*-all.cc",


### PR DESCRIPTION
With Bazel's new C++ sandboxing, it doesn't build without this.