### PR TITLE
Add gtest-internal-inl.h to textual_headers of gtest.

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -18,6 +18,7 @@ cc_library(
         "googletest/include",
     ],
     linkopts = ["-pthread"],
+    textual_hdrs = ["googletest/src/gtest-internal-inl.h"],
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
This makes it possible to compile cctz with the Bazel sandbox.