### PR TITLE
conditional setting of CXXFLAGS in Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,15 @@
 /bazel-*
 # ignore non-bazel build products
 /build
+*.a
+*.o
+*.d
+classic
+epoch_shift
+example1
+example2
+example3
+example4
+hello
+time_tool
+

--- a/Makefile
+++ b/Makefile
@@ -29,25 +29,20 @@
 
 # local configuration
 CXXFLAGS ?= -O3
+LDFLAGS ?= -O3
 STD ?= c++11
 PREFIX = /usr/local
 DESTDIR =
 
-# possible support for googletest
-## TESTS = civil_time_test time_zone_lookup_test time_zone_format_test
-## TEST_FLAGS = ...
-## TEST_LIBS = ...
 VPATH = $(SRC)include:$(SRC)src:$(SRC)examples
 CC = $(CXX)
-CPPFLAGS = -Wall -I$(SRC)include -std=$(STD) -pthread \
-	   $(TEST_FLAGS) -fPIC -MMD
+CXXFLAGS += -g -Wall -I$(SRC)include -std=$(STD) -pthread -fPIC -MMD
 ARFLAGS = rcs
-LDFLAGS = -pthread
+LDFLAGS += -pthread
 LDLIBS = $(TEST_LIBS)
 SHARED_LDFLAGS = -shared
 
 INSTALL = install
-SUDO =
 
 CCTZ = cctz
 CCTZ_LIB = lib$(CCTZ).a
@@ -85,16 +80,16 @@ $(CCTZ_SHARED_LIB): $(CCTZ_OBJS)
 install: install_hdrs install_lib
 
 install_hdrs: $(CCTZ_HDRS)
-	$(SUDO) $(INSTALL) -d $(DESTDIR)$(PREFIX)/include
-	$(SUDO) $(INSTALL) -m 644 -p $? $(DESTDIR)$(PREFIX)/include
+	$(INSTALL) -d $(DESTDIR)$(PREFIX)/include
+	$(INSTALL) -m 644 -p $? $(DESTDIR)$(PREFIX)/include
 
 install_lib: $(CCTZ_LIB)
-	$(SUDO) $(INSTALL) -d $(DESTDIR)$(PREFIX)/lib
-	$(SUDO) $(INSTALL) -m 644 -p $? $(DESTDIR)$(PREFIX)/lib
+	$(INSTALL) -d $(DESTDIR)$(PREFIX)/lib
+	$(INSTALL) -m 644 -p $? $(DESTDIR)$(PREFIX)/lib
 
 install_shared_lib: $(CCTZ_SHARED_LIB)
-	$(SUDO) $(INSTALL) -d $(DESTDIR)$(PREFIX)/lib
-	$(SUDO) $(INSTALL) -m 644 -p $? $(DESTDIR)$(PREFIX)/lib
+	$(INSTALL) -d $(DESTDIR)$(PREFIX)/lib
+	$(INSTALL) -m 644 -p $? $(DESTDIR)$(PREFIX)/lib
 
 clean:
 	@$(RM) $(EXAMPLES:=.dSYM) $(EXAMPLES:=.o) $(EXAMPLES:=.d) $(EXAMPLES)

--- a/Makefile
+++ b/Makefile
@@ -28,9 +28,8 @@
 #         install install_shared_lib
 
 # local configuration
-CXX = g++
-STD = c++11
-OPT = -O
+CXXFLAGS ?= -O3
+STD ?= c++11
 PREFIX = /usr/local
 DESTDIR =
 
@@ -38,11 +37,10 @@ DESTDIR =
 ## TESTS = civil_time_test time_zone_lookup_test time_zone_format_test
 ## TEST_FLAGS = ...
 ## TEST_LIBS = ...
-
 VPATH = $(SRC)include:$(SRC)src:$(SRC)examples
 CC = $(CXX)
 CPPFLAGS = -Wall -I$(SRC)include -std=$(STD) -pthread \
-	   $(TEST_FLAGS) $(OPT) -fPIC -MMD
+	   $(TEST_FLAGS) -fPIC -MMD
 ARFLAGS = rcs
 LDFLAGS = -pthread
 LDLIBS = $(TEST_LIBS)

--- a/Makefile
+++ b/Makefile
@@ -35,13 +35,12 @@ PREFIX = /usr/local
 DESTDIR =
 
 VPATH = $(SRC)include:$(SRC)src:$(SRC)examples
-CC = $(CXX)
 CXXFLAGS += -g -Wall -I$(SRC)include -std=$(STD) -pthread -fPIC -MMD
 ARFLAGS = rcs
 LDFLAGS += -pthread
 LDLIBS = $(TEST_LIBS)
 SHARED_LDFLAGS = -shared
-
+LINK.o = $(LINK.cc)
 INSTALL = install
 
 CCTZ = cctz


### PR DESCRIPTION
-O3 as default, keep -std separate in case of an older compiler (they can use -e to override in that case).