### PR TITLE
fix valgrind/s Conditional jump or move depends on uninitialised value(s)

### DIFF
--- a/src/time_zone_info.h
+++ b/src/time_zone_info.h
@@ -135,8 +135,8 @@ class TimeZoneInfo : public TimeZoneIf {
   bool extended_;            // future_spec_ was used to generate transitions
   cctz::year_t last_year_;   // the final year of the generated transitions
 
-  mutable std::atomic<std::size_t> local_time_hint_;  // BreakTime() hint
-  mutable std::atomic<std::size_t> time_local_hint_;  // MakeTime() hint
+  mutable std::atomic<std::size_t> local_time_hint_ = {};  // BreakTime() hint
+  mutable std::atomic<std::size_t> time_local_hint_ = {};  // MakeTime() hint
 };
 
 }  // namespace cctz


### PR DESCRIPTION
=00:00:00:16.762 149400== Conditional jump or move depends on uninitialised value(s)
==00:00:00:16.762 149400==    at 0x2C002FA: cctz::TimeZoneInfo::BreakTime(std::chrono::time_point<std::chrono::_V2::system_clock, std::chrono::duration<long, std::ratio<1l, 1l> > > const&) const (time_zone_info.cc:644)
==00:00:00:16.762 149400==    by 0x2BFBEC4: BreakTime (time_zone_impl.h:45)
==00:00:00:16.762 149400==    by 0x2BFBEC4: cctz::time_zone::lookup(std::chrono::time_point<std::chrono::_V2::system_clock, std::chrono::duration<long, std::ratio<1l, 1l> > > const&) const (time_zone_lookup.cc:29)
==00:00:00:16.762 149400==    by 0x2BF28DA: lookup<std::chrono::duration<long int, std::ratio<1l, 1000000000l> > > (time_zone.h:83)