### PR TITLE
Guard get_offset_abbr() impls in src/time_zone_libc.cc

### DIFF
--- a/src/time_zone_libc.cc
+++ b/src/time_zone_libc.cc
@@ -64,16 +64,20 @@ OffsetAbbr get_offset_abbr(const std::tm& tm) {
 //
 // Returns an OffsetAbbr using std::tm fields with various spellings.
 //
+#if !defined(tm_gmtoff) && !defined(tm_zone)
 template <typename T>
 OffsetAbbr get_offset_abbr(const T& tm, decltype(&T::tm_gmtoff) = nullptr,
                            decltype(&T::tm_zone) = nullptr) {
   return {tm.tm_gmtoff, tm.tm_zone};
 }
+#endif  // !defined(tm_gmtoff) && !defined(tm_zone)
+#if !defined(__tm_gmtoff) && !defined(__tm_zone)
 template <typename T>
 OffsetAbbr get_offset_abbr(const T& tm, decltype(&T::__tm_gmtoff) = nullptr,
                            decltype(&T::__tm_zone) = nullptr) {
   return {tm.__tm_gmtoff, tm.__tm_zone};
 }
+#endif  // !defined(__tm_gmtoff) && !defined(__tm_zone)
 #endif
 
 }  // namespace


### PR DESCRIPTION
Some implementations of libc (MUSL in this case) #define __tm_zone and
__tm_gmtoff to tm_zone and tm_gmtoff respectively. This causes a
"redefinition of default argument" upon compilation.

TESTING:
//third_party/cctz:civil_time_test PASSED in 2.1s
//third_party/cctz:time_zone_format_test PASSED in 4.0s
//third_party/cctz:time_zone_lookup_test PASSED in 3.7s