### PR TITLE
Fix extern declaration of default_factory with initializer

### DIFF
--- a/src/time_zone_info.cc
+++ b/src/time_zone_info.cc
@@ -69,7 +69,8 @@ std::unique_ptr<cctz::ZoneInfoSource> DefaultFactory(
 // zone_info_source.h).
 #if defined(_MSC_VER)
 extern ZoneInfoSourceFactory zone_info_source_factory;
-extern ZoneInfoSourceFactory default_factory = DefaultFactory;
+extern ZoneInfoSourceFactory default_factory;
+ZoneInfoSourceFactory default_factory = DefaultFactory;
 #if defined(_M_IX86)
 #pragma comment( \
     linker,      \


### PR DESCRIPTION
This declaration of default_factory as extern, but with an initializer,
elicits a warning when compiled using clang.  This declaration is on the
MSVC codepath, but the warning fires when library is built for Windows
using clang-cl.