### PR TITLE
Declaring kDigits static to avoid a codegen bug in VS2017.

### DIFF
--- a/src/time_zone_fixed.cc
+++ b/src/time_zone_fixed.cc
@@ -28,7 +28,7 @@ namespace {
 const char kFixedOffsetPrefix[] = "Fixed/";
 
 int Parse02d(const char* p) {
-  const char kDigits[] = "0123456789";
+  static const char kDigits[] = "0123456789";
   if (const char* ap = std::strchr(kDigits, *p)) {
     int v = static_cast<int>(ap - kDigits);
     if (const char* bp = std::strchr(kDigits, *++p)) {


### PR DESCRIPTION
The issue should be fixed shortly, but until then.
https://developercommunity.visualstudio.com/comments/114235/view.html