### PR TITLE
Fix ambiguous conditional expression w/ Clang+Windows

### DIFF
--- a/src/time_zone_format.cc
+++ b/src/time_zone_format.cc
@@ -48,7 +48,8 @@ char* strptime(const char* s, const char* fmt, std::tm* tm) {
   std::istringstream input(s);
   input >> std::get_time(tm, fmt);
   if (input.fail()) return nullptr;
-  return const_cast<char*>(s) + (input.eof() ? strlen(s) : input.tellg());
+  return const_cast<char*>(s) +
+         (input.eof() ? strlen(s) : static_cast<std::size_t>(input.tellg()));
 }
 #endif
 


### PR DESCRIPTION
When built with Clang on Windows, I hit this error:
cctz/src/time_zone_format.cc(51,46):  error: conditional expression is ambiguous; 'size_t' (aka 'unsigned long long') can be converted to 'std::basic_istream<char, std::char_traits<char> >::pos_type' (aka 'fpos<_Mbstatet>') and vice versa
  return const_cast<char*>(s) + (input.eof() ? strlen(s) : input.tellg());