### PR TITLE
Update CMake (remove getopt special case)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,38 @@ set(CMAKE_MODULE_PATH
 
 include(CheckCXXSymbolExists)
 include(CTest)
+include(FeatureSummary)
 
 option(BUILD_EXAMPLES "Whether or not to build examples" ON)
+
+if (BUILD_TESTING)
+  find_package(benchmark)
+  set_package_properties(benchmark PROPERTIES
+    TYPE REQUIRED
+    DESCRIPTION "a microbenchmark support library"
+    URL "https://github.com/google/benchmark"
+  )
+
+  find_package(GMock)
+  set_package_properties(GMock PROPERTIES
+    TYPE REQUIRED
+    DESCRIPTION "the Google C++ mocking framework"
+    URL "https://github.com/google/googletest"
+  )
+
+  find_package(GTest)
+  set_package_properties(GTest PROPERTIES
+    TYPE REQUIRED
+    DESCRIPTION "the Google C++ test framework"
+    URL "https://github.com/google/googletest"
+  )
+
+  find_package(Threads)
+  set_package_properties(Threads PROPERTIES
+    TYPE REQUIRED
+    DESCRIPTION "the system thread library"
+  )
+endif()
 
 # Starting from CMake >= 3.1, if a specific standard is required,
 # it can be set from the command line with:
@@ -71,11 +101,6 @@ if (BUILD_EXAMPLES)
 endif()
 
 if (BUILD_TESTING)
-  find_package(benchmark REQUIRED)
-  find_package(GMock REQUIRED)
-  find_package(GTest REQUIRED)
-  find_package(Threads REQUIRED)
-
   add_executable(civil_time_test src/civil_time_test.cc)
   cctz_target_set_cxx_standard(civil_time_test)
   target_include_directories(civil_time_test PRIVATE ${GTEST_INCLUDE_DIRS})
@@ -119,3 +144,5 @@ if (BUILD_TESTING)
   cctz_target_set_cxx_standard(benchmarks)
   target_link_libraries(benchmarks cctz::cctz benchmark::benchmark)
 endif()
+
+feature_summary(WHAT ALL FATAL_ON_MISSING_REQUIRED_PACKAGES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,6 @@ set(CMAKE_MODULE_PATH
   ${PROJECT_SOURCE_DIR}/cmake/modules
   ${CMAKE_MODULE_PATH})
 
-include(CheckCXXSymbolExists)
 include(CTest)
 include(FeatureSummary)
 
@@ -82,19 +81,9 @@ add_library(cctz::cctz ALIAS cctz)
 
 target_include_directories(cctz PUBLIC include)
 
-# the getopt_long function used by time_tool is not available on all platforms,
-# for example this is not available by default on Windows
-if (NOT DEFINED HAVE_GETOPT_LONG)
-  set(show_time_tool_msg 1)
-endif()
-check_cxx_symbol_exists(getopt_long getopt.h HAVE_GETOPT_LONG)
-if (HAVE_GETOPT_LONG)
-  add_executable(time_tool src/time_tool.cc)
-  cctz_target_set_cxx_standard(time_tool)
-  target_link_libraries(time_tool cctz::cctz)
-elseif(show_time_tool_msg)
-    message(STATUS "Disable time_tool as getopt_long is not available")
-endif()
+add_executable(time_tool src/time_tool.cc)
+cctz_target_set_cxx_standard(time_tool)
+target_link_libraries(time_tool cctz::cctz)
 
 if (BUILD_EXAMPLES)
   add_subdirectory(examples)

--- a/README.md
+++ b/README.md
@@ -30,14 +30,17 @@ that should work if you're unable to use Bazel.)
 
 1.  Download/install
     [Bazel](https://docs.bazel.build/versions/master/install.html)
-2.  Get the cctz source: `git clone https://github.com/google/cctz.git` then `cd
-    cctz`
+2.  Get the cctz source: `git clone https://github.com/google/cctz.git`
+    then `cd cctz`
 3.  Build cctz and run the tests: `bazel test :all`
 
-With CMake: 1. Make sure you have CMake >= 2.8.12 installed. 2. Get the cctz
-source: `git clone https://github.com/google/cctz.git` then `cd cctz`. 3. Build
-cctz so that is can be used by shared libraries and run the tests (use
-`-DBUILD_TESTING=OFF` to skip the tests):
+With CMake:
+
+1.  Make sure you have CMake >= 2.8.12 installed.
+2.  Get the cctz source: `git clone https://github.com/google/cctz.git`
+    then `cd cctz`.
+3.  Build cctz so that is can be used by shared libraries
+    and run the tests (use `-DBUILD_TESTING=OFF` to skip the tests):
 
         mkdir mybuild
         cd mybuild
@@ -45,7 +48,7 @@ cctz so that is can be used by shared libraries and run the tests (use
         cmake --build . --config Release
         ctest
 
-1.  Use in your CMake-based project with:
+4.  Use in your CMake-based project with:
 
     ```cmake
     add_subdirectory(cctz)


### PR DESCRIPTION
There are 3 distincts commits, I can split the PR if you prefer.

One of the change is a follow up to your comment (removal of getopt):
- https://github.com/google/cctz/pull/54#issuecomment-348040315

The others are cosmetic changes.