### PR TITLE
Add a workspace() rule with the project name to the WORKSPACE file

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,3 +1,5 @@
+workspace(name = "com_googlesource_code_cctz")
+
 # GoogleTest/GoogleMock framework. Used by most unit-tests.
 http_archive(
     name = "com_google_googletest",


### PR DESCRIPTION
Name chosen to match the one specified for this repo in abseil-cpp/WORKSPACE.

This line is needed to point a fetched copy of abseil-cpp at a fetched copy of this repo as a local_repository.