### PR TITLE
Fix native WebAssembly emscripten build

### DIFF
--- a/src/time_zone_libc.cc
+++ b/src/time_zone_libc.cc
@@ -54,7 +54,8 @@ OffsetAbbr get_offset_abbr(const std::tm& tm) {
   const char* abbr = tzname[is_dst];
   return {off, abbr};
 }
-#elif defined(__native_client__) || defined(__myriad2__) || defined(__asmjs__)
+#elif defined(__native_client__) || defined(__myriad2__) || \
+    defined(__EMSCRIPTEN__)
 // Uses the globals: 'timezone' and 'tzname'.
 OffsetAbbr get_offset_abbr(const std::tm& tm) {
   const bool is_dst = tm.tm_isdst > 0;


### PR DESCRIPTION
`__EMSCRIPTEN__` is defined by the emscripten toolchain whichever
compiler it uses internall. ` __asmjs__` and `__wasm__` are defined in
the two different compiler frontends that emscripten can use.