### PR TITLE
Enable C++14 constexpr for more compilers

### DIFF
--- a/include/cctz/civil_time_detail.h
+++ b/include/cctz/civil_time_detail.h
@@ -20,8 +20,9 @@
 #include <ostream>
 #include <type_traits>
 
-// Disable constexpr support unless we are using clang in C++14 mode.
-#if __clang__ && __cpp_constexpr >= 201304
+// Disable constexpr support unless we are in C++14 mode.
+#if (defined(__cpp_constexpr) && __cpp_constexpr >= 201304) || \
+    (defined(_MSC_VER) && _MSC_VER >= 1900)
 #define CONSTEXPR_D constexpr  // data
 #define CONSTEXPR_F constexpr  // function
 #define CONSTEXPR_M constexpr  // member

--- a/src/civil_time_test.cc
+++ b/src/civil_time_test.cc
@@ -35,7 +35,8 @@ std::string Format(const T& t) {
 
 }  // namespace
 
-#if __clang__ && __cpp_constexpr >= 201304
+#if (defined(__cpp_constexpr) && __cpp_constexpr >= 201304) || \
+    (defined(_MSC_VER) && _MSC_VER >= 1900)
 // Construction constexpr tests
 
 TEST(CivilTime, Normal) {
@@ -317,7 +318,7 @@ TEST(CivilTime, YearDay) {
   constexpr int yd = get_yearday(cd);
   static_assert(yd == 28, "YearDay");
 }
-#endif  // __clang__ && __cpp_constexpr >= 201304
+#endif  // __cpp_constexpr >= 201304
 
 // The remaining tests do not use constexpr.
 


### PR DESCRIPTION
Many compilers can handle C++14 constexpr already, let's not restrict ourselves to clang only.

Visual Studio 2015 does not have `__cpp_constexpr` macro, but the compiler always defaults to C++14 mode, so it is enough to just check the compiler version.

Tested with Mingw64 GCC 7.1.0, Clang/MSVC (master) and Visual Studio 2017 15.5, all in C++14 mode.