### PR TITLE
Fixed build under MinGW.

### DIFF
--- a/src/time_zone_format.cc
+++ b/src/time_zone_format.cc
@@ -13,7 +13,7 @@
 //   limitations under the License.
 
 #if !defined(HAS_STRPTIME)
-# if !defined(_MSC_VER)
+# if !defined(_MSC_VER) && !defined(__MINGW32__)
 #  define HAS_STRPTIME 1  // assume everyone has strptime() except windows
 # endif
 #endif


### PR DESCRIPTION
In this code Windows previously meant Visual C++. This patch extends this to MinGW (both 32 and 64).

Kind regards,
Vladimir.