### PR TITLE
First test if _MSC_VER is defined to avoid -Wundef

### DIFF
--- a/include/cctz/civil_time_detail.h
+++ b/include/cctz/civil_time_detail.h
@@ -21,7 +21,7 @@
 #include <type_traits>
 
 // Disable constexpr support unless we are in C++14 mode.
-#if __cpp_constexpr >= 201304 || _MSC_VER >= 1910
+#if __cpp_constexpr >= 201304 || (defined(_MSC_VER) && _MSC_VER >= 1910)
 #define CONSTEXPR_D constexpr  // data
 #define CONSTEXPR_F constexpr  // function
 #define CONSTEXPR_M constexpr  // member


### PR DESCRIPTION
CCTZ clients may need to compile their code with the -Wundef warning
flag. It will be helpful if CCTZ header files can be compiled without
the -Wundef warning.

How to avoid the -Wundef warning: If a macro may be undefined, we need
to first test whether the macro is defined before testing its value. We
can't rely on the C preprocessor rule that an undefined macro has the
value 0L.