### PR TITLE
Minor fix: Updated HTTP URLs to HTTPS: Apache Headers and Miscellaneous URLs

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+#   https://www.apache.org/licenses/LICENSE-2.0
 #
 #   Unless required by applicable law or agreed to in writing, software
 #   distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/cctz/civil_time.h
+++ b/include/cctz/civil_time.h
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,11 +12,13 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-#ifndef CCTZ_CIVIL_TIME_H_
-#define CCTZ_CIVIL_TIME_H_
+#ifndef ABSL_TIME_INTERNAL_CCTZ_CIVIL_TIME_H_
+#define ABSL_TIME_INTERNAL_CCTZ_CIVIL_TIME_H_
 
-#include "cctz/civil_time_detail.h"
+#include "absl/time/internal/cctz/include/cctz/civil_time_detail.h"
 
+namespace absl {
+namespace time_internal {
 namespace cctz {
 
 // The term "civil time" refers to the legally recognized human-scale time
@@ -321,5 +323,7 @@ using detail::prev_weekday;
 using detail::get_yearday;
 
 }  // namespace cctz
+}  // namespace time_internal
+}  // namespace absl
 
-#endif  // CCTZ_CIVIL_TIME_H_
+#endif  // ABSL_TIME_INTERNAL_CCTZ_CIVIL_TIME_H_

--- a/include/cctz/civil_time_detail.h
+++ b/include/cctz/civil_time_detail.h
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,8 +12,8 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-#ifndef CCTZ_CIVIL_TIME_DETAIL_H_
-#define CCTZ_CIVIL_TIME_DETAIL_H_
+#ifndef ABSL_TIME_INTERNAL_CCTZ_CIVIL_TIME_DETAIL_H_
+#define ABSL_TIME_INTERNAL_CCTZ_CIVIL_TIME_DETAIL_H_
 
 #include <cstdint>
 #include <limits>
@@ -31,6 +31,8 @@
 #define CONSTEXPR_M
 #endif
 
+namespace absl {
+namespace time_internal {
 namespace cctz {
 
 // Support years that at least span the range of 64-bit time_t values.
@@ -324,6 +326,37 @@ CONSTEXPR_F fields align(year_tag, fields f) noexcept {
 
 ////////////////////////////////////////////////////////////////////////
 
+namespace impl {
+
+template <typename H>
+H AbslHashValueImpl(second_tag, H h, fields f) {
+  return H::combine(std::move(h), f.y, f.m, f.d, f.hh, f.mm, f.ss);
+}
+template <typename H>
+H AbslHashValueImpl(minute_tag, H h, fields f) {
+  return H::combine(std::move(h), f.y, f.m, f.d, f.hh, f.mm);
+}
+template <typename H>
+H AbslHashValueImpl(hour_tag, H h, fields f) {
+  return H::combine(std::move(h), f.y, f.m, f.d, f.hh);
+}
+template <typename H>
+H AbslHashValueImpl(day_tag, H h, fields f) {
+  return H::combine(std::move(h), f.y, f.m, f.d);
+}
+template <typename H>
+H AbslHashValueImpl(month_tag, H h, fields f) {
+  return H::combine(std::move(h), f.y, f.m);
+}
+template <typename H>
+H AbslHashValueImpl(year_tag, H h, fields f) {
+  return H::combine(std::move(h), f.y);
+}
+
+}  // namespace impl
+
+////////////////////////////////////////////////////////////////////////
+
 template <typename T>
 class civil_time {
  public:
@@ -412,6 +445,11 @@ class civil_time {
   }
   friend CONSTEXPR_F diff_t operator-(civil_time lhs, civil_time rhs) noexcept {
     return difference(T{}, lhs.f_, rhs.f_);
+  }
+
+  template <typename H>
+  friend H AbslHashValue(H h, civil_time a) {
+    return impl::AbslHashValueImpl(T{}, std::move(h), a.f_);
   }
 
  private:
@@ -546,9 +584,11 @@ std::ostream& operator<<(std::ostream& os, weekday wd);
 
 }  // namespace detail
 }  // namespace cctz
+}  // namespace time_internal
+}  // namespace absl
 
 #undef CONSTEXPR_M
 #undef CONSTEXPR_F
 #undef CONSTEXPR_D
 
-#endif  // CCTZ_CIVIL_TIME_DETAIL_H_
+#endif  // ABSL_TIME_INTERNAL_CCTZ_CIVIL_TIME_DETAIL_H_

--- a/include/cctz/time_zone.h
+++ b/include/cctz/time_zone.h
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,16 +17,18 @@
 // times (represented by cctz::civil_second) using the rules defined by
 // a time zone (cctz::time_zone).
 
-#ifndef CCTZ_TIME_ZONE_H_
-#define CCTZ_TIME_ZONE_H_
+#ifndef ABSL_TIME_INTERNAL_CCTZ_TIME_ZONE_H_
+#define ABSL_TIME_INTERNAL_CCTZ_TIME_ZONE_H_
 
 #include <chrono>
 #include <cstdint>
 #include <string>
 #include <utility>
 
-#include "cctz/civil_time.h"
+#include "absl/time/internal/cctz/include/cctz/civil_time.h"
 
+namespace absl {
+namespace time_internal {
 namespace cctz {
 
 // Convenience aliases. Not intended as public API points.
@@ -70,7 +72,7 @@ split_seconds(const time_point<seconds>& tp) {
 //
 // See also:
 // - http://www.iana.org/time-zones
-// - http://en.wikipedia.org/wiki/Zoneinfo
+// - https://en.wikipedia.org/wiki/Zoneinfo
 class time_zone {
  public:
   time_zone() : time_zone(nullptr) {}  // Equivalent to UTC
@@ -207,7 +209,7 @@ class time_zone {
   // version() and description() provide additional information about the
   // time zone. The content of each of the returned strings is unspecified,
   // however, when the IANA Time Zone Database is the underlying data source
-  // the version() string will be in the familar form (e.g, "2018e") or
+  // the version() std::string will be in the familar form (e.g, "2018e") or
   // empty when unavailable.
   //
   // Note: These functions are for informational or testing purposes only.
@@ -220,6 +222,11 @@ class time_zone {
   }
   friend bool operator!=(time_zone lhs, time_zone rhs) {
     return !(lhs == rhs);
+  }
+
+  template <typename H>
+  friend H AbslHashValue(H h, time_zone tz) {
+    return H::combine(std::move(h), &tz.effective_impl());
   }
 
   class Impl;
@@ -372,5 +379,7 @@ inline bool parse(const std::string& fmt, const std::string& input,
 }
 
 }  // namespace cctz
+}  // namespace time_internal
+}  // namespace absl
 
-#endif  // CCTZ_TIME_ZONE_H_
+#endif  // ABSL_TIME_INTERNAL_CCTZ_TIME_ZONE_H_

--- a/include/cctz/zone_info_source.h
+++ b/include/cctz/zone_info_source.h
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,14 +12,16 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-#ifndef CCTZ_ZONE_INFO_SOURCE_H_
-#define CCTZ_ZONE_INFO_SOURCE_H_
+#ifndef ABSL_TIME_INTERNAL_CCTZ_ZONE_INFO_SOURCE_H_
+#define ABSL_TIME_INTERNAL_CCTZ_ZONE_INFO_SOURCE_H_
 
 #include <cstddef>
 #include <functional>
 #include <memory>
 #include <string>
 
+namespace absl {
+namespace time_internal {
 namespace cctz {
 
 // A stdio-like interface for providing zoneinfo data for a particular zone.
@@ -32,21 +34,25 @@ class ZoneInfoSource {
 
   // Until the zoneinfo data supports versioning information, we provide
   // a way for a ZoneInfoSource to indicate it out-of-band.  The default
-  // implementation returns an empty string.
+  // implementation returns an empty std::string.
   virtual std::string Version() const;
 };
 
 }  // namespace cctz
+}  // namespace time_internal
+}  // namespace absl
 
+namespace absl {
+namespace time_internal {
 namespace cctz_extension {
 
 // A function-pointer type for a factory that returns a ZoneInfoSource
 // given the name of a time zone and a fallback factory.  Returns null
 // when the data for the named zone cannot be found.
 using ZoneInfoSourceFactory =
-    std::unique_ptr<cctz::ZoneInfoSource> (*)(
+    std::unique_ptr<absl::time_internal::cctz::ZoneInfoSource> (*)(
         const std::string&,
-        const std::function<std::unique_ptr<cctz::ZoneInfoSource>(
+        const std::function<std::unique_ptr<absl::time_internal::cctz::ZoneInfoSource>(
             const std::string&)>&);
 
 // The user can control the mapping of zone names to zoneinfo data by
@@ -84,5 +90,7 @@ using ZoneInfoSourceFactory =
 extern ZoneInfoSourceFactory zone_info_source_factory;
 
 }  // namespace cctz_extension
+}  // namespace time_internal
+}  // namespace absl
 
-#endif  // CCTZ_ZONE_INFO_SOURCE_H_
+#endif  // ABSL_TIME_INTERNAL_CCTZ_ZONE_INFO_SOURCE_H_

--- a/src/cctz_benchmark.cc
+++ b/src/cctz_benchmark.cc
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,
@@ -21,11 +21,13 @@
 #include <vector>
 
 #include "benchmark/benchmark.h"
-#include "cctz/civil_time.h"
-#include "cctz/time_zone.h"
+#include "absl/time/internal/cctz/include/cctz/civil_time.h"
+#include "absl/time/internal/cctz/include/cctz/time_zone.h"
 #include "time_zone_impl.h"
 
 namespace {
+
+namespace cctz = absl::time_internal::cctz;
 
 void BM_Difference_Days(benchmark::State& state) {
   const cctz::civil_day c(2014, 8, 22);

--- a/src/civil_time_detail.cc
+++ b/src/civil_time_detail.cc
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,12 +12,14 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-#include "cctz/civil_time_detail.h"
+#include "absl/time/internal/cctz/include/cctz/civil_time_detail.h"
 
 #include <iomanip>
 #include <ostream>
 #include <sstream>
 
+namespace absl {
+namespace time_internal {
 namespace cctz {
 namespace detail {
 
@@ -84,3 +86,5 @@ std::ostream& operator<<(std::ostream& os, weekday wd) {
 
 }  // namespace detail
 }  // namespace cctz
+}  // namespace time_internal
+}  // namespace absl

--- a/src/civil_time_test.cc
+++ b/src/civil_time_test.cc
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-#include "cctz/civil_time.h"
+#include "absl/time/internal/cctz/include/cctz/civil_time.h"
 
 #include <iomanip>
 #include <limits>
@@ -22,6 +22,8 @@
 
 #include "gtest/gtest.h"
 
+namespace absl {
+namespace time_internal {
 namespace cctz {
 
 namespace {
@@ -1043,3 +1045,5 @@ TEST(CivilTime, FirstThursdayInMonth) {
 }
 
 }  // namespace cctz
+}  // namespace time_internal
+}  // namespace absl

--- a/src/time_zone_fixed.cc
+++ b/src/time_zone_fixed.cc
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,
@@ -20,6 +20,8 @@
 #include <cstring>
 #include <string>
 
+namespace absl {
+namespace time_internal {
 namespace cctz {
 
 namespace {
@@ -132,3 +134,5 @@ std::string FixedOffsetToAbbr(const seconds& offset) {
 }
 
 }  // namespace cctz
+}  // namespace time_internal
+}  // namespace absl

--- a/src/time_zone_fixed.h
+++ b/src/time_zone_fixed.h
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,13 +12,15 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-#ifndef CCTZ_TIME_ZONE_FIXED_H_
-#define CCTZ_TIME_ZONE_FIXED_H_
+#ifndef ABSL_TIME_INTERNAL_CCTZ_TIME_ZONE_FIXED_H_
+#define ABSL_TIME_INTERNAL_CCTZ_TIME_ZONE_FIXED_H_
 
 #include <string>
 
-#include "cctz/time_zone.h"
+#include "absl/time/internal/cctz/include/cctz/time_zone.h"
 
+namespace absl {
+namespace time_internal {
 namespace cctz {
 
 // Helper functions for dealing with the names and abbreviations
@@ -41,5 +43,7 @@ std::string FixedOffsetToName(const seconds& offset);
 std::string FixedOffsetToAbbr(const seconds& offset);
 
 }  // namespace cctz
+}  // namespace time_internal
+}  // namespace absl
 
-#endif  // CCTZ_TIME_ZONE_FIXED_H_
+#endif  // ABSL_TIME_INTERNAL_CCTZ_TIME_ZONE_FIXED_H_

--- a/src/time_zone_format.cc
+++ b/src/time_zone_format.cc
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,7 +18,7 @@
 # endif
 #endif
 
-#include "cctz/time_zone.h"
+#include "absl/time/internal/cctz/include/cctz/time_zone.h"
 
 #include <cctype>
 #include <chrono>
@@ -34,9 +34,11 @@
 #include <sstream>
 #endif
 
-#include "cctz/civil_time.h"
+#include "absl/time/internal/cctz/include/cctz/civil_time.h"
 #include "time_zone_if.h"
 
+namespace absl {
+namespace time_internal {
 namespace cctz {
 namespace detail {
 
@@ -175,7 +177,7 @@ void FormatTM(std::string* out, const std::string& fmt, const std::tm& tm) {
   // strftime(3) returns the number of characters placed in the output
   // array (which may be 0 characters).  It also returns 0 to indicate
   // an error, like the array wasn't large enough.  To accommodate this,
-  // the following code grows the buffer size from 2x the format string
+  // the following code grows the buffer size from 2x the format std::string
   // length up to 32x.
   for (std::size_t i = 2; i != 32; i *= 2) {
     std::size_t buf_size = fmt.size() * i;
@@ -825,7 +827,7 @@ bool parse(const std::string& format, const std::string& input,
   // Skip any remaining whitespace.
   while (std::isspace(*data)) ++data;
 
-  // parse() must consume the entire input string.
+  // parse() must consume the entire input std::string.
   if (*data != '\0') {
     if (err != nullptr) *err = "Illegal trailing data in input string";
     return false;
@@ -903,3 +905,5 @@ bool parse(const std::string& format, const std::string& input,
 
 }  // namespace detail
 }  // namespace cctz
+}  // namespace time_internal
+}  // namespace absl

--- a/src/time_zone_format_test.cc
+++ b/src/time_zone_format_test.cc
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,19 +12,21 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-#include "cctz/time_zone.h"
+#include "absl/time/internal/cctz/include/cctz/time_zone.h"
 
 #include <chrono>
 #include <iomanip>
 #include <sstream>
 #include <string>
 
-#include "cctz/civil_time.h"
+#include "absl/time/internal/cctz/include/cctz/civil_time.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace chrono = std::chrono;
 
+namespace absl {
+namespace time_internal {
 namespace cctz {
 
 namespace {
@@ -87,7 +89,7 @@ TEST(Format, TimePointResolution) {
   EXPECT_EQ("03:04:05",
             format(kFmt, chrono::time_point_cast<chrono::seconds>(t0), utc));
   EXPECT_EQ("03:04:05",
-            format(kFmt, chrono::time_point_cast<cctz::seconds>(t0), utc));
+            format(kFmt, chrono::time_point_cast<absl::time_internal::cctz::seconds>(t0), utc));
   EXPECT_EQ("03:04:00",
             format(kFmt, chrono::time_point_cast<chrono::minutes>(t0), utc));
   EXPECT_EQ("03:00:00",
@@ -97,8 +99,8 @@ TEST(Format, TimePointResolution) {
 TEST(Format, TimePointExtendedResolution) {
   const char kFmt[] = "%H:%M:%E*S";
   const time_zone utc = utc_time_zone();
-  const time_point<cctz::seconds> tp =
-      chrono::time_point_cast<cctz::seconds>(
+  const time_point<absl::time_internal::cctz::seconds> tp =
+      chrono::time_point_cast<absl::time_internal::cctz::seconds>(
           chrono::system_clock::from_time_t(0)) +
       chrono::hours(12) + chrono::minutes(34) + chrono::seconds(56);
 
@@ -161,7 +163,9 @@ TEST(Format, PosixConversions) {
   TestFormatSpecifier(tp, tz, "%M", "00");
   TestFormatSpecifier(tp, tz, "%S", "00");
   TestFormatSpecifier(tp, tz, "%U", "00");
+#if !defined(__EMSCRIPTEN__)
   TestFormatSpecifier(tp, tz, "%w", "4");  // 4=Thursday
+#endif
   TestFormatSpecifier(tp, tz, "%W", "00");
   TestFormatSpecifier(tp, tz, "%y", "70");
   TestFormatSpecifier(tp, tz, "%Y", "1970");
@@ -425,7 +429,7 @@ TEST(Format, CompareExtendSecondsVsSubseconds) {
 TEST(Format, ExtendedOffset) {
   const auto tp = chrono::system_clock::from_time_t(0);
 
-  auto tz = fixed_time_zone(cctz::seconds::zero());
+  auto tz = fixed_time_zone(absl::time_internal::cctz::seconds::zero());
   TestFormatSpecifier(tp, tz, "%z", "+0000");
   TestFormatSpecifier(tp, tz, "%:z", "+00:00");
   TestFormatSpecifier(tp, tz, "%Ez", "+00:00");
@@ -506,7 +510,7 @@ TEST(Format, ExtendedOffset) {
 TEST(Format, ExtendedSecondOffset) {
   const auto tp = chrono::system_clock::from_time_t(0);
 
-  auto tz = fixed_time_zone(cctz::seconds::zero());
+  auto tz = fixed_time_zone(absl::time_internal::cctz::seconds::zero());
   TestFormatSpecifier(tp, tz, "%E*z", "+00:00:00");
   TestFormatSpecifier(tp, tz, "%::z", "+00:00:00");
   TestFormatSpecifier(tp, tz, "%:::z", "+00");
@@ -722,7 +726,7 @@ TEST(Parse, TimePointExtendedResolution) {
   const char kFmt[] = "%H:%M:%E*S";
   const time_zone utc = utc_time_zone();
 
-  time_point<cctz::seconds> tp;
+  time_point<absl::time_internal::cctz::seconds> tp;
   detail::femtoseconds fs;
   EXPECT_TRUE(detail::parse(kFmt, "12:34:56.123456789012345", utc, &tp, &fs));
   EXPECT_EQ("12:34:56.123456789012345", detail::format(kFmt, tp, fs, utc));
@@ -761,7 +765,7 @@ TEST(Parse, WithTimeZone) {
   EXPECT_TRUE(load_time_zone("America/Los_Angeles", &tz));
   time_point<chrono::nanoseconds> tp;
 
-  // We can parse a string without a UTC offset if we supply a timezone.
+  // We can parse a std::string without a UTC offset if we supply a timezone.
   EXPECT_TRUE(parse("%Y-%m-%d %H:%M:%S", "2013-06-28 19:08:09", tz, &tp));
   ExpectTime(tp, tz, 2013, 6, 28, 19, 8, 9, -7 * 60 * 60, true, "PDT");
 
@@ -1259,7 +1263,7 @@ TEST(Parse, ExtendedSubecondsScan) {
 
 TEST(Parse, ExtendedOffset) {
   const time_zone utc = utc_time_zone();
-  time_point<cctz::seconds> tp;
+  time_point<absl::time_internal::cctz::seconds> tp;
 
   EXPECT_TRUE(parse("%Ez", "+00:00", utc, &tp));
   EXPECT_EQ(convert(civil_second(1970, 1, 1, 0, 0, 0), utc), tp);
@@ -1290,7 +1294,7 @@ TEST(Parse, ExtendedOffset) {
 
 TEST(Parse, ExtendedSecondOffset) {
   const time_zone utc = utc_time_zone();
-  time_point<cctz::seconds> tp;
+  time_point<absl::time_internal::cctz::seconds> tp;
 
   for (auto fmt : {"%Ez", "%E*z", "%:z", "%::z", "%:::z"}) {
     EXPECT_TRUE(parse(fmt, "+00:00:00", utc, &tp));
@@ -1338,7 +1342,7 @@ TEST(Parse, ExtendedSecondOffset) {
 TEST(Parse, ExtendedYears) {
   const time_zone utc = utc_time_zone();
   const char e4y_fmt[] = "%E4Y%m%d";  // no separators
-  time_point<cctz::seconds> tp;
+  time_point<absl::time_internal::cctz::seconds> tp;
 
   // %E4Y consumes exactly four chars, including any sign.
   EXPECT_TRUE(parse(e4y_fmt, "-9991127", utc, &tp));
@@ -1381,33 +1385,33 @@ TEST(Parse, RFC3339Format) {
 
 TEST(Parse, MaxRange) {
   const time_zone utc = utc_time_zone();
-  time_point<cctz::seconds> tp;
+  time_point<absl::time_internal::cctz::seconds> tp;
 
   // tests the upper limit using +00:00 offset
   EXPECT_TRUE(
       parse(RFC3339_sec, "292277026596-12-04T15:30:07+00:00", utc, &tp));
-  EXPECT_EQ(tp, time_point<cctz::seconds>::max());
+  EXPECT_EQ(tp, time_point<absl::time_internal::cctz::seconds>::max());
   EXPECT_FALSE(
       parse(RFC3339_sec, "292277026596-12-04T15:30:08+00:00", utc, &tp));
 
   // tests the upper limit using -01:00 offset
   EXPECT_TRUE(
       parse(RFC3339_sec, "292277026596-12-04T14:30:07-01:00", utc, &tp));
-  EXPECT_EQ(tp, time_point<cctz::seconds>::max());
+  EXPECT_EQ(tp, time_point<absl::time_internal::cctz::seconds>::max());
   EXPECT_FALSE(
       parse(RFC3339_sec, "292277026596-12-04T15:30:07-01:00", utc, &tp));
 
   // tests the lower limit using +00:00 offset
   EXPECT_TRUE(
       parse(RFC3339_sec, "-292277022657-01-27T08:29:52+00:00", utc, &tp));
-  EXPECT_EQ(tp, time_point<cctz::seconds>::min());
+  EXPECT_EQ(tp, time_point<absl::time_internal::cctz::seconds>::min());
   EXPECT_FALSE(
       parse(RFC3339_sec, "-292277022657-01-27T08:29:51+00:00", utc, &tp));
 
   // tests the lower limit using +01:00 offset
   EXPECT_TRUE(
       parse(RFC3339_sec, "-292277022657-01-27T09:29:52+01:00", utc, &tp));
-  EXPECT_EQ(tp, time_point<cctz::seconds>::min());
+  EXPECT_EQ(tp, time_point<absl::time_internal::cctz::seconds>::min());
   EXPECT_FALSE(
       parse(RFC3339_sec, "-292277022657-01-27T08:29:51+01:00", utc, &tp));
 
@@ -1451,6 +1455,10 @@ TEST(FormatParse, RoundTrip) {
 #if defined(_WIN32) || defined(_WIN64)
   // Initial investigations indicate the %c does not roundtrip on Windows.
   // TODO: Figure out what is going on here (perhaps a locale problem).
+#elif defined(__EMSCRIPTEN__)
+  // strftime() and strptime() use different defintions for "%c" under
+  // emscripten (see https://github.com/kripken/emscripten/pull/7491),
+  // causing its round-trip test to fail.
 #else
   // Even though we don't know what %c will produce, it should roundtrip,
   // but only in the 0-offset timezone.
@@ -1466,20 +1474,22 @@ TEST(FormatParse, RoundTrip) {
 
 TEST(FormatParse, RoundTripDistantFuture) {
   const time_zone utc = utc_time_zone();
-  const time_point<cctz::seconds> in = time_point<cctz::seconds>::max();
+  const time_point<absl::time_internal::cctz::seconds> in = time_point<absl::time_internal::cctz::seconds>::max();
   const std::string s = format(RFC3339_full, in, utc);
-  time_point<cctz::seconds> out;
+  time_point<absl::time_internal::cctz::seconds> out;
   EXPECT_TRUE(parse(RFC3339_full, s, utc, &out)) << s;
   EXPECT_EQ(in, out);
 }
 
 TEST(FormatParse, RoundTripDistantPast) {
   const time_zone utc = utc_time_zone();
-  const time_point<cctz::seconds> in = time_point<cctz::seconds>::min();
+  const time_point<absl::time_internal::cctz::seconds> in = time_point<absl::time_internal::cctz::seconds>::min();
   const std::string s = format(RFC3339_full, in, utc);
-  time_point<cctz::seconds> out;
+  time_point<absl::time_internal::cctz::seconds> out;
   EXPECT_TRUE(parse(RFC3339_full, s, utc, &out)) << s;
   EXPECT_EQ(in, out);
 }
 
 }  // namespace cctz
+}  // namespace time_internal
+}  // namespace absl

--- a/src/time_zone_if.cc
+++ b/src/time_zone_if.cc
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,6 +16,8 @@
 #include "time_zone_info.h"
 #include "time_zone_libc.h"
 
+namespace absl {
+namespace time_internal {
 namespace cctz {
 
 std::unique_ptr<TimeZoneIf> TimeZoneIf::Load(const std::string& name) {
@@ -35,3 +37,5 @@ std::unique_ptr<TimeZoneIf> TimeZoneIf::Load(const std::string& name) {
 TimeZoneIf::~TimeZoneIf() {}
 
 }  // namespace cctz
+}  // namespace time_internal
+}  // namespace absl

--- a/src/time_zone_if.h
+++ b/src/time_zone_if.h
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,17 +12,19 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-#ifndef CCTZ_TIME_ZONE_IF_H_
-#define CCTZ_TIME_ZONE_IF_H_
+#ifndef ABSL_TIME_INTERNAL_CCTZ_TIME_ZONE_IF_H_
+#define ABSL_TIME_INTERNAL_CCTZ_TIME_ZONE_IF_H_
 
 #include <chrono>
 #include <cstdint>
 #include <memory>
 #include <string>
 
-#include "cctz/civil_time.h"
-#include "cctz/time_zone.h"
+#include "absl/time/internal/cctz/include/cctz/civil_time.h"
+#include "absl/time/internal/cctz/include/cctz/time_zone.h"
 
+namespace absl {
+namespace time_internal {
 namespace cctz {
 
 // A simple interface used to hide time-zone complexities from time_zone::Impl.
@@ -64,5 +66,7 @@ inline time_point<seconds> FromUnixSeconds(std::int_fast64_t t) {
 }
 
 }  // namespace cctz
+}  // namespace time_internal
+}  // namespace absl
 
-#endif  // CCTZ_TIME_ZONE_IF_H_
+#endif  // ABSL_TIME_INTERNAL_CCTZ_TIME_ZONE_IF_H_

--- a/src/time_zone_impl.cc
+++ b/src/time_zone_impl.cc
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,
@@ -21,6 +21,8 @@
 
 #include "time_zone_fixed.h"
 
+namespace absl {
+namespace time_internal {
 namespace cctz {
 
 namespace {
@@ -102,3 +104,5 @@ const time_zone::Impl* time_zone::Impl::UTCImpl() {
 }
 
 }  // namespace cctz
+}  // namespace time_internal
+}  // namespace absl

--- a/src/time_zone_impl.h
+++ b/src/time_zone_impl.h
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,17 +12,19 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-#ifndef CCTZ_TIME_ZONE_IMPL_H_
-#define CCTZ_TIME_ZONE_IMPL_H_
+#ifndef ABSL_TIME_INTERNAL_CCTZ_TIME_ZONE_IMPL_H_
+#define ABSL_TIME_INTERNAL_CCTZ_TIME_ZONE_IMPL_H_
 
 #include <memory>
 #include <string>
 
-#include "cctz/civil_time.h"
-#include "cctz/time_zone.h"
+#include "absl/time/internal/cctz/include/cctz/civil_time.h"
+#include "absl/time/internal/cctz/include/cctz/time_zone.h"
 #include "time_zone_if.h"
 #include "time_zone_info.h"
 
+namespace absl {
+namespace time_internal {
 namespace cctz {
 
 // time_zone::Impl is the internal object referenced by a cctz::time_zone.
@@ -67,7 +69,7 @@ class time_zone::Impl {
     return zone_->PrevTransition(tp, trans);
   }
 
-  // Returns an implementation-defined version string for this time zone.
+  // Returns an implementation-defined version std::string for this time zone.
   std::string Version() const { return zone_->Version(); }
 
   // Returns an implementation-defined description of this time zone.
@@ -82,5 +84,7 @@ class time_zone::Impl {
 };
 
 }  // namespace cctz
+}  // namespace time_internal
+}  // namespace absl
 
-#endif  // CCTZ_TIME_ZONE_IMPL_H_
+#endif  // ABSL_TIME_INTERNAL_CCTZ_TIME_ZONE_IMPL_H_

--- a/src/time_zone_info.cc
+++ b/src/time_zone_info.cc
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,
@@ -25,7 +25,7 @@
 // a grain of salt.
 //
 // For more information see tzfile(5), http://www.iana.org/time-zones, or
-// http://en.wikipedia.org/wiki/Zoneinfo.
+// https://en.wikipedia.org/wiki/Zoneinfo.
 //
 // Note that we assume the proleptic Gregorian calendar and 60-second
 // minutes throughout.
@@ -45,10 +45,12 @@
 #include <sstream>
 #include <string>
 
-#include "cctz/civil_time.h"
+#include "absl/time/internal/cctz/include/cctz/civil_time.h"
 #include "time_zone_fixed.h"
 #include "time_zone_posix.h"
 
+namespace absl {
+namespace time_internal {
 namespace cctz {
 
 namespace {
@@ -520,7 +522,7 @@ bool TimeZoneInfo::Load(const std::string& name, ZoneInfoSource* zip) {
 
   // If we did not find version information during the standard loading
   // process (as of tzh_version '3' that is unsupported), then ask the
-  // ZoneInfoSource for any out-of-bound version string it may be privy to.
+  // ZoneInfoSource for any out-of-bound version std::string it may be privy to.
   if (version_.empty()) {
     version_ = zip->Version();
   }
@@ -970,3 +972,5 @@ bool TimeZoneInfo::PrevTransition(const time_point<seconds>& tp,
 }
 
 }  // namespace cctz
+}  // namespace time_internal
+}  // namespace absl

--- a/src/time_zone_info.h
+++ b/src/time_zone_info.h
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,8 +12,8 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-#ifndef CCTZ_TIME_ZONE_INFO_H_
-#define CCTZ_TIME_ZONE_INFO_H_
+#ifndef ABSL_TIME_INTERNAL_CCTZ_TIME_ZONE_INFO_H_
+#define ABSL_TIME_INTERNAL_CCTZ_TIME_ZONE_INFO_H_
 
 #include <atomic>
 #include <cstddef>
@@ -21,12 +21,14 @@
 #include <string>
 #include <vector>
 
-#include "cctz/civil_time.h"
-#include "cctz/time_zone.h"
-#include "cctz/zone_info_source.h"
+#include "absl/time/internal/cctz/include/cctz/civil_time.h"
+#include "absl/time/internal/cctz/include/cctz/time_zone.h"
+#include "absl/time/internal/cctz/include/cctz/zone_info_source.h"
 #include "time_zone_if.h"
 #include "tzfile.h"
 
+namespace absl {
+namespace time_internal {
 namespace cctz {
 
 // A transition to a new UTC offset.
@@ -128,5 +130,7 @@ class TimeZoneInfo : public TimeZoneIf {
 };
 
 }  // namespace cctz
+}  // namespace time_internal
+}  // namespace absl
 
-#endif  // CCTZ_TIME_ZONE_INFO_H_
+#endif  // ABSL_TIME_INTERNAL_CCTZ_TIME_ZONE_INFO_H_

--- a/src/time_zone_libc.cc
+++ b/src/time_zone_libc.cc
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,
@@ -24,9 +24,11 @@
 #include <tuple>
 #include <utility>
 
-#include "cctz/civil_time.h"
-#include "cctz/time_zone.h"
+#include "absl/time/internal/cctz/include/cctz/civil_time.h"
+#include "absl/time/internal/cctz/include/cctz/time_zone.h"
 
+namespace absl {
+namespace time_internal {
 namespace cctz {
 
 namespace {
@@ -284,3 +286,5 @@ std::string TimeZoneLibC::Description() const {
 }
 
 }  // namespace cctz
+}  // namespace time_internal
+}  // namespace absl

--- a/src/time_zone_libc.h
+++ b/src/time_zone_libc.h
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,13 +12,15 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-#ifndef CCTZ_TIME_ZONE_LIBC_H_
-#define CCTZ_TIME_ZONE_LIBC_H_
+#ifndef ABSL_TIME_INTERNAL_CCTZ_TIME_ZONE_LIBC_H_
+#define ABSL_TIME_INTERNAL_CCTZ_TIME_ZONE_LIBC_H_
 
 #include <string>
 
 #include "time_zone_if.h"
 
+namespace absl {
+namespace time_internal {
 namespace cctz {
 
 // A time zone backed by gmtime_r(3), localtime_r(3), and mktime(3),
@@ -45,5 +47,7 @@ class TimeZoneLibC : public TimeZoneIf {
 };
 
 }  // namespace cctz
+}  // namespace time_internal
+}  // namespace absl
 
-#endif  // CCTZ_TIME_ZONE_LIBC_H_
+#endif  // ABSL_TIME_INTERNAL_CCTZ_TIME_ZONE_LIBC_H_

--- a/src/time_zone_lookup.cc
+++ b/src/time_zone_lookup.cc
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-#include "cctz/time_zone.h"
+#include "absl/time/internal/cctz/include/cctz/time_zone.h"
 
 #if defined(__ANDROID__)
 #include <sys/system_properties.h>
@@ -27,6 +27,8 @@
 #include "time_zone_fixed.h"
 #include "time_zone_impl.h"
 
+namespace absl {
+namespace time_internal {
 namespace cctz {
 
 #if defined(__ANDROID__) && __ANDROID_API__ >= 21
@@ -162,3 +164,5 @@ time_zone local_time_zone() {
 }
 
 }  // namespace cctz
+}  // namespace time_internal
+}  // namespace absl

--- a/src/time_zone_posix.cc
+++ b/src/time_zone_posix.cc
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,6 +19,8 @@
 #include <limits>
 #include <string>
 
+namespace absl {
+namespace time_internal {
 namespace cctz {
 
 namespace {
@@ -149,3 +151,5 @@ bool ParsePosixSpec(const std::string& spec, PosixTimeZone* res) {
 }
 
 }  // namespace cctz
+}  // namespace time_internal
+}  // namespace absl

--- a/src/time_zone_posix.h
+++ b/src/time_zone_posix.h
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,
@@ -49,12 +49,14 @@
 //     }
 //   }
 
-#ifndef CCTZ_TIME_ZONE_POSIX_H_
-#define CCTZ_TIME_ZONE_POSIX_H_
+#ifndef ABSL_TIME_INTERNAL_CCTZ_TIME_ZONE_POSIX_H_
+#define ABSL_TIME_INTERNAL_CCTZ_TIME_ZONE_POSIX_H_
 
 #include <cstdint>
 #include <string>
 
+namespace absl {
+namespace time_internal {
 namespace cctz {
 
 // The date/time of the transition. The date is specified as either:
@@ -120,5 +122,7 @@ struct PosixTimeZone {
 bool ParsePosixSpec(const std::string& spec, PosixTimeZone* res);
 
 }  // namespace cctz
+}  // namespace time_internal
+}  // namespace absl
 
-#endif  // CCTZ_TIME_ZONE_POSIX_H_
+#endif  // ABSL_TIME_INTERNAL_CCTZ_TIME_ZONE_POSIX_H_

--- a/src/tzfile.h
+++ b/src/tzfile.h
@@ -80,13 +80,13 @@ struct tzhead {
 ** If tzh_version is '2' or greater, the above is followed by a second instance
 ** of tzhead and a second instance of the data in which each coded transition
 ** time uses 8 rather than 4 chars,
-** then a POSIX-TZ-environment-variable-style string for use in handling
+** then a POSIX-TZ-environment-variable-style std::string for use in handling
 ** instants after the last transition time stored in the file
 ** (with nothing between the newlines if there is no POSIX representation for
 ** such instants).
 **
 ** If tz_version is '3' or greater, the above is extended as follows.
-** First, the POSIX TZ string's hour offset may range from -167
+** First, the POSIX TZ std::string's hour offset may range from -167
 ** through 167 as compared to the POSIX-required 0 through 24.
 ** Second, its DST start time may be January 1 at 00:00 and its stop
 ** time December 31 at 24:00 plus the difference between DST and

--- a/src/zone_info_source.cc
+++ b/src/zone_info_source.cc
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,8 +12,10 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-#include "cctz/zone_info_source.h"
+#include "absl/time/internal/cctz/include/cctz/zone_info_source.h"
 
+namespace absl {
+namespace time_internal {
 namespace cctz {
 
 // Defined out-of-line to avoid emitting a weak vtable in all TUs.
@@ -21,16 +23,20 @@ ZoneInfoSource::~ZoneInfoSource() {}
 std::string ZoneInfoSource::Version() const { return std::string(); }
 
 }  // namespace cctz
+}  // namespace time_internal
+}  // namespace absl
 
+namespace absl {
+namespace time_internal {
 namespace cctz_extension {
 
 namespace {
 
 // A default for cctz_extension::zone_info_source_factory, which simply
 // defers to the fallback factory.
-std::unique_ptr<cctz::ZoneInfoSource> DefaultFactory(
+std::unique_ptr<absl::time_internal::cctz::ZoneInfoSource> DefaultFactory(
     const std::string& name,
-    const std::function<std::unique_ptr<cctz::ZoneInfoSource>(
+    const std::function<std::unique_ptr<absl::time_internal::cctz::ZoneInfoSource>(
         const std::string& name)>& fallback_factory) {
   return fallback_factory(name);
 }
@@ -47,11 +53,11 @@ ZoneInfoSourceFactory default_factory = DefaultFactory;
 #if defined(_M_IX86)
 #pragma comment( \
     linker,      \
-    "/alternatename:?zone_info_source_factory@cctz_extension@@3P6A?AV?$unique_ptr@VZoneInfoSource@cctz@@U?$default_delete@VZoneInfoSource@cctz@@@std@@@std@@ABV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@3@ABV?$function@$$A6A?AV?$unique_ptr@VZoneInfoSource@cctz@@U?$default_delete@VZoneInfoSource@cctz@@@std@@@std@@ABV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@2@@Z@3@@ZA=?default_factory@cctz_extension@@3P6A?AV?$unique_ptr@VZoneInfoSource@cctz@@U?$default_delete@VZoneInfoSource@cctz@@@std@@@std@@ABV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@3@ABV?$function@$$A6A?AV?$unique_ptr@VZoneInfoSource@cctz@@U?$default_delete@VZoneInfoSource@cctz@@@std@@@std@@ABV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@2@@Z@3@@ZA")
+    "/alternatename:?zone_info_source_factory@cctz_extension@time_internal@absl@@3P6A?AV?$unique_ptr@VZoneInfoSource@cctz@time_internal@absl@@U?$default_delete@VZoneInfoSource@cctz@time_internal@absl@@@std@@@std@@ABV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@5@ABV?$function@$$A6A?AV?$unique_ptr@VZoneInfoSource@cctz@time_internal@absl@@U?$default_delete@VZoneInfoSource@cctz@time_internal@absl@@@std@@@std@@ABV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@2@@Z@5@@ZA=?default_factory@cctz_extension@time_internal@absl@@3P6A?AV?$unique_ptr@VZoneInfoSource@cctz@time_internal@absl@@U?$default_delete@VZoneInfoSource@cctz@time_internal@absl@@@std@@@std@@ABV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@5@ABV?$function@$$A6A?AV?$unique_ptr@VZoneInfoSource@cctz@time_internal@absl@@U?$default_delete@VZoneInfoSource@cctz@time_internal@absl@@@std@@@std@@ABV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@2@@Z@5@@ZA")
 #elif defined(_M_IA_64) || defined(_M_AMD64) || defined(_M_ARM64)
 #pragma comment( \
     linker,      \
-    "/alternatename:?zone_info_source_factory@cctz_extension@@3P6A?AV?$unique_ptr@VZoneInfoSource@cctz@@U?$default_delete@VZoneInfoSource@cctz@@@std@@@std@@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@3@AEBV?$function@$$A6A?AV?$unique_ptr@VZoneInfoSource@cctz@@U?$default_delete@VZoneInfoSource@cctz@@@std@@@std@@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@2@@Z@3@@ZEA=?default_factory@cctz_extension@@3P6A?AV?$unique_ptr@VZoneInfoSource@cctz@@U?$default_delete@VZoneInfoSource@cctz@@@std@@@std@@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@3@AEBV?$function@$$A6A?AV?$unique_ptr@VZoneInfoSource@cctz@@U?$default_delete@VZoneInfoSource@cctz@@@std@@@std@@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@2@@Z@3@@ZEA")
+    "/alternatename:?zone_info_source_factory@cctz_extension@time_internal@absl@@3P6A?AV?$unique_ptr@VZoneInfoSource@cctz@time_internal@absl@@U?$default_delete@VZoneInfoSource@cctz@time_internal@absl@@@std@@@std@@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@5@AEBV?$function@$$A6A?AV?$unique_ptr@VZoneInfoSource@cctz@time_internal@absl@@U?$default_delete@VZoneInfoSource@cctz@time_internal@absl@@@std@@@std@@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@2@@Z@5@@ZEA=?default_factory@cctz_extension@time_internal@absl@@3P6A?AV?$unique_ptr@VZoneInfoSource@cctz@time_internal@absl@@U?$default_delete@VZoneInfoSource@cctz@time_internal@absl@@@std@@@std@@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@5@AEBV?$function@$$A6A?AV?$unique_ptr@VZoneInfoSource@cctz@time_internal@absl@@U?$default_delete@VZoneInfoSource@cctz@time_internal@absl@@@std@@@std@@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@2@@Z@5@@ZEA")
 #else
 #error Unsupported MSVC platform
 #endif
@@ -69,3 +75,5 @@ ZoneInfoSourceFactory zone_info_source_factory = DefaultFactory;
 #endif  // _MSC_VER
 
 }  // namespace cctz_extension
+}  // namespace time_internal
+}  // namespace absl

--- a/testdata/zoneinfo/iso3166.tab
+++ b/testdata/zoneinfo/iso3166.tab
@@ -10,7 +10,7 @@
 #
 # 1.  ISO 3166-1 alpha-2 country code, current as of
 #     ISO 3166-1 N905 (2016-11-15).  See: Updates on ISO 3166-1
-#     http://isotc.iso.org/livelink/livelink/Open/16944257
+#     https://isotc.iso.org/livelink/livelink/Open/16944257
 # 2.  The usual English name for the coded region,
 #     chosen so that alphabetic sorting of subsets produces helpful lists.
 #     This is not the same as the English name in the ISO 3166 tables.


### PR DESCRIPTION
I was asked to submit this by a member of abseil, seen in the comments of my pull request to their repository: https://github.com/abseil/abseil-cpp/pull/270 
I exhaustively searched and changed HTTP URLs to HTTPS where possible. The occasional HTTP still exists for certain links because they don't yet support HTTPS.
This is done so that a secure connection is established when users click on URLs in the repository.