### PR TITLE
Make local_time_zone() work on iOS

### DIFF
--- a/src/time_zone_lookup.cc
+++ b/src/time_zone_lookup.cc
@@ -20,6 +20,11 @@
 #include <dlfcn.h>
 #endif
 #endif
+
+#if defined(__APPLE__)
+#include <CoreFoundation/CFTimeZone.h>
+#endif
+
 #include <cstdlib>
 #include <cstring>
 #include <string>
@@ -119,6 +124,11 @@ time_zone local_time_zone() {
   char* tz_env = nullptr;
 #if defined(_MSC_VER)
   _dupenv_s(&tz_env, nullptr, "TZ");
+#elif defined(__APPLE__)
+  CFTimeZoneRef system_time_zone = CFTimeZoneCopySystem();
+  CFStringRef tz_name = CFTimeZoneGetName(system_time_zone);
+  tz_env = strdup(CFStringGetCStringPtr(tz_name, CFStringGetSystemEncoding()));
+  CFRelease(system_time_zone);
 #else
   tz_env = std::getenv("TZ");
 #endif
@@ -150,6 +160,8 @@ time_zone local_time_zone() {
   const std::string name = zone;
 #if defined(_MSC_VER)
   free(localtime_env);
+  free(tz_env);
+#elif defined(__APPLE__)
   free(tz_env);
 #endif
 


### PR DESCRIPTION
It looks like "/etc/localtime" can't be accessed on iOS, so `local_time_zone()` always falls back to UTC.

I used Core Foundation methods that are available on every Apple platform (since OS X 10.0, apparently).

Tested with iOS 10, 11 and 12.1.4