### PR TITLE
Use CFTimeZoneCopyDefault() instead of CFTimeZoneCopySystem()

### DIFF
--- a/src/time_zone_lookup.cc
+++ b/src/time_zone_lookup.cc
@@ -125,7 +125,7 @@ time_zone local_time_zone() {
 #if defined(_MSC_VER)
   _dupenv_s(&tz_env, nullptr, "TZ");
 #elif defined(__APPLE__)
-  CFTimeZoneRef system_time_zone = CFTimeZoneCopySystem();
+  CFTimeZoneRef system_time_zone = CFTimeZoneCopyDefault();
   CFStringRef tz_name = CFTimeZoneGetName(system_time_zone);
   tz_env = strdup(CFStringGetCStringPtr(tz_name, CFStringGetSystemEncoding()));
   CFRelease(system_time_zone);


### PR DESCRIPTION
To allow overriding the timezone with `CFTimeZoneSetDefault` (to run tests)

`CFTimeZoneCopyDefault()` checks if a default timezone is set and if there's none it falls back to the system time zone.