### PR TITLE
Remove use of CFStringGetCStringPtr

### DIFF
--- a/src/time_zone_lookup.cc
+++ b/src/time_zone_lookup.cc
@@ -126,8 +126,15 @@ time_zone local_time_zone() {
   _dupenv_s(&tz_env, nullptr, "TZ");
 #elif defined(__APPLE__)
   CFTimeZoneRef system_time_zone = CFTimeZoneCopyDefault();
-  CFStringRef tz_name = CFTimeZoneGetName(system_time_zone);
-  tz_env = strdup(CFStringGetCStringPtr(tz_name, CFStringGetSystemEncoding()));
+  if (CFStringRef tz_name = CFTimeZoneGetName(system_time_zone)) {
+    CFStringEncoding encoding = kCFStringEncodingUTF8;
+    CFIndex length = CFStringGetLength(tz_name);
+    CFIndex max_size = CFStringGetMaximumSizeForEncoding(length, encoding);
+    std::vector<char> buffer(max_size + 1);
+    if (CFStringGetCString(tz_name, &buffer[0], buffer.size(), encoding)) {
+      tz_env = strdup(&buffer[0]);
+    }
+  }
   CFRelease(system_time_zone);
 #else
   tz_env = std::getenv("TZ");


### PR DESCRIPTION
`CFStringGetCStringPtr` might return nullptr, which causes `strdup` to crash. This PR now uses `CFStringGetString`, which writes to a local buffer.

Fixes #98 