### PR TITLE
Link to CoreFoundation in time_zone

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -15,16 +15,18 @@
 licenses(["notice"])  # Apache License
 
 config_setting(
-      name = "osx",
-      constraint_values = [
-          "@bazel_tools//platforms:osx"
-      ]
-  )config_setting(
-      name = "ios",
-      constraint_values = [
-          "@bazel_tools//platforms:ios",
-      ]
-  )
+    name = "osx",
+    constraint_values = [
+        "@bazel_tools//platforms:osx"
+    ],
+)
+
+config_setting(
+    name = "ios",
+    constraint_values = [
+        "@bazel_tools//platforms:ios",
+    ],
+)
 
 ### libraries
 

--- a/BUILD
+++ b/BUILD
@@ -14,6 +14,18 @@
 
 licenses(["notice"])  # Apache License
 
+config_setting(
+      name = "osx",
+      constraint_values = [
+          "@bazel_tools//platforms:osx"
+      ]
+  )config_setting(
+      name = "ios",
+      constraint_values = [
+          "@bazel_tools//platforms:ios",
+      ]
+  )
+
 ### libraries
 
 cc_library(
@@ -51,6 +63,15 @@ cc_library(
         "include/cctz/time_zone.h",
         "include/cctz/zone_info_source.h",
     ],
+    linkopts = select({
+        "//:osx": [
+            "-framework Foundation",
+        ],
+        "//:ios": [
+            "-framework Foundation",
+        ],
+        "//conditions:default": [],
+    }),
     includes = ["include"],
     visibility = ["//visibility:public"],
     deps = [":civil_time"],


### PR DESCRIPTION
This broke Abseil's cmake and Bazel builds, eg https://github.com/abseil/abseil-cpp/issues/291

This is required to fix the Bazel builds as well.