### PR TITLE
Cater to -Wundef by also checking defined() in #if tests

### DIFF
--- a/include/cctz/civil_time_detail.h
+++ b/include/cctz/civil_time_detail.h
@@ -21,7 +21,7 @@
 #include <type_traits>
 
 // Disable constexpr support unless we are in C++14 mode.
-#if __cpp_constexpr >= 201304 || _MSC_VER >= 1910
+#if __cpp_constexpr >= 201304 || (defined(_MSC_VER) && _MSC_VER >= 1910)
 #define CONSTEXPR_D constexpr  // data
 #define CONSTEXPR_F constexpr  // function
 #define CONSTEXPR_M constexpr  // member

--- a/src/civil_time_test.cc
+++ b/src/civil_time_test.cc
@@ -35,7 +35,7 @@ std::string Format(const T& t) {
 
 }  // namespace
 
-#if __cpp_constexpr >= 201304 || _MSC_VER >= 1910
+#if __cpp_constexpr >= 201304 || (defined(_MSC_VER) && _MSC_VER >= 1910)
 // Construction constexpr tests
 
 TEST(CivilTime, Normal) {
@@ -317,7 +317,7 @@ TEST(CivilTime, YearDay) {
   constexpr int yd = get_yearday(cd);
   static_assert(yd == 28, "YearDay");
 }
-#endif  // __cpp_constexpr >= 201304 || _MSC_VER >= 1910
+#endif  // __cpp_constexpr >= 201304 || (defined(_MSC_VER) && _MSC_VER >= 1910)
 
 // The remaining tests do not use constexpr.
 

--- a/src/time_zone_lookup.cc
+++ b/src/time_zone_lookup.cc
@@ -16,7 +16,7 @@
 
 #if defined(__ANDROID__)
 #include <sys/system_properties.h>
-#if __ANDROID_API__ >= 21
+#if defined(__ANDROID_API__) && __ANDROID_API__ >= 21
 #include <dlfcn.h>
 #endif
 #endif
@@ -35,7 +35,7 @@
 
 namespace cctz {
 
-#if defined(__ANDROID__) && __ANDROID_API__ >= 21
+#if defined(__ANDROID__) && defined(__ANDROID_API__) && __ANDROID_API__ >= 21
 namespace {
 // Android 'L' removes __system_property_get() from the NDK, however
 // it is still a hidden symbol in libc so we use dlsym() to access it.


### PR DESCRIPTION
In cases where substitution of a 0 for an undefined symbol
would work just fine, we now additionally check if the symbol
is defined.  That is, `#if defined(FOO) && FOO >= N` instead
of just `#if FOO >= N`.  This caters to users of -Wundef.

Note that we don't do this for __cpp_constexpr as we require
C++11, and all C++11 compilers should provide a value for that.