### PR TITLE
Change the suggestions for the non-strict next/prev-weekday calls

### DIFF
--- a/include/cctz/civil_time.h
+++ b/include/cctz/civil_time.h
@@ -304,9 +304,9 @@ using detail::get_weekday;
 //
 //   civil_day d = ...
 //   // Gets the following Thursday if d is not already Thursday
-//   civil_day thurs1 = prev_weekday(d, weekday::thursday) + 7;
+//   civil_day thurs1 = next_weekday(d - 1, weekday::thursday);
 //   // Gets the previous Thursday if d is not already Thursday
-//   civil_day thurs2 = next_weekday(d, weekday::thursday) - 7;
+//   civil_day thurs2 = prev_weekday(d + 1, weekday::thursday);
 //
 using detail::next_weekday;
 using detail::prev_weekday;

--- a/src/civil_time_test.cc
+++ b/src/civil_time_test.cc
@@ -1033,7 +1033,7 @@ TEST(CivilTime, LeapYears) {
 
 TEST(CivilTime, FirstThursdayInMonth) {
   const civil_day nov1(2014, 11, 1);
-  const civil_day thursday = prev_weekday(nov1, weekday::thursday) + 7;
+  const civil_day thursday = next_weekday(nov1 - 1, weekday::thursday);
   EXPECT_EQ("2014-11-06", Format(thursday));
 
   // Bonus: Date of Thanksgiving in the United States


### PR DESCRIPTION
Previously we suggested `prev_weekday(d, weekday::thursday) + 7`
to get the _following_ Thursday if d is not already a Thursday,
but `next_weekday(d - 1, weekday::thursday)` is more intuitive,
and probably even a little faster.

Similarly for the _previous_ Thursday if d is not already a
Thursday, suggest `prev_weekday(d + 1, weekday::thursday)`
instead of `next_weekday(d, weekday::thursday) - 7`.