### PR TITLE
Fix -Wunused-member-function warning.

### DIFF
--- a/src/time_zone_info.cc
+++ b/src/time_zone_info.cc
@@ -664,7 +664,6 @@ std::unique_ptr<ZoneInfoSource> FileZoneInfoSource::Open(
   return std::unique_ptr<ZoneInfoSource>(new FileZoneInfoSource(fp, length));
 }
 
-#if defined(__ANDROID__)
 class AndroidZoneInfoSource : public FileZoneInfoSource {
  public:
   static std::unique_ptr<ZoneInfoSource> Open(const std::string& name);
@@ -718,7 +717,6 @@ std::unique_ptr<ZoneInfoSource> AndroidZoneInfoSource::Open(
 
   return nullptr;
 }
-#endif  // __ANDROID__
 
 }  // namespace
 
@@ -736,9 +734,7 @@ bool TimeZoneInfo::Load(const std::string& name) {
   auto zip = cctz_extension::zone_info_source_factory(
       name, [](const std::string& name) -> std::unique_ptr<ZoneInfoSource> {
         if (auto zip = FileZoneInfoSource::Open(name)) return zip;
-#if defined(__ANDROID__)
         if (auto zip = AndroidZoneInfoSource::Open(name)) return zip;
-#endif  // __ANDROID__
         return nullptr;
       });
   return zip != nullptr && Load(name, zip.get());


### PR DESCRIPTION
XCode/Clang complains that the constructor to
AndroidZoneInfoSource is unused.