### PR TITLE
Add casts to suppress implicit-conversion-loss warnings

### DIFF
--- a/src/time_zone_libc.cc
+++ b/src/time_zone_libc.cc
@@ -133,7 +133,7 @@ bool make_time(const civil_second& cs, int is_dst, std::time_t* t, int* off) {
       return false;
     }
   }
-  *off = tm_gmtoff(tm);
+  *off = static_cast<int>(tm_gmtoff(tm));
   return true;
 }
 
@@ -200,7 +200,7 @@ time_zone::absolute_lookup TimeZoneLibC::BreakTime(
   const year_t year = tmp->tm_year + year_t{1900};
   al.cs = civil_second(year, tmp->tm_mon + 1, tmp->tm_mday,
                        tmp->tm_hour, tmp->tm_min, tmp->tm_sec);
-  al.offset = tm_gmtoff(*tmp);
+  al.offset = static_cast<int>(tm_gmtoff(*tmp));
   al.abbr = local_ ? tm_zone(*tmp) : "UTC";  // as expected by cctz
   al.is_dst = tmp->tm_isdst > 0;
   return al;


### PR DESCRIPTION
On platforms where `tm::tm_gmtoff` is wider than an `int`
we risk implicit conversion loss, but we already assume
`int` is at least 32 bits and `tm::tm_gmtoff` should never
exceed about 50k in absolute value, so no actual loss occurs.