### PR TITLE
Fix time_zone_libc.cc compilation error

### DIFF
--- a/src/time_zone_libc.cc
+++ b/src/time_zone_libc.cc
@@ -67,6 +67,10 @@ auto tm_zone(const std::tm& tm) -> decltype(tzname[0]) {
 auto tm_gmtoff(const std::tm& tm) -> decltype(tm.tm_gmtoff) {
   return tm.tm_gmtoff;
 }
+#elif defined(__tm_gmtoff)
+auto tm_gmtoff(const std::tm& tm) -> decltype(tm.__tm_gmtoff) {
+  return tm.__tm_gmtoff;
+}
 #else
 template <typename T>
 auto tm_gmtoff(const T& tm) -> decltype(tm.tm_gmtoff) {
@@ -80,6 +84,10 @@ auto tm_gmtoff(const T& tm) -> decltype(tm.__tm_gmtoff) {
 #if defined(tm_zone)
 auto tm_zone(const std::tm& tm) -> decltype(tm.tm_zone) {
   return tm.tm_zone;
+}
+#elif defined(__tm_zone)
+auto tm_zone(const std::tm& tm) -> decltype(tm.__tm_zone) {
+  return tm.__tm_zone;
 }
 #else
 template <typename T>


### PR DESCRIPTION
In some library implementations, `__tm_zone`/`__tm_gmtoff` are compatibility macros for `tm_zone`/`tm_gmtoff`, rather than the other way around.  In that case, the SFINAE detection in this file doesn't work and leads to ODR violations.

Add a guard for the `__tm_zone` macro, mirroring the existing one for `tm_zone` (and the same for `tm_gmtoff`).