### PR TITLE
Avoid strcpy() calls to quash MSVC warnings

### DIFF
--- a/src/time_tool.cc
+++ b/src/time_tool.cc
@@ -233,7 +233,7 @@ void ZoneDump(bool zdump, const std::string& fmt, cctz::time_zone zone,
 }
 
 const char* Basename(const char* p) {
-  if (const char* b = strrchr(p, '/')) return ++b;
+  if (const char* b = std::strrchr(p, '/')) return ++b;
   return p;
 }
 
@@ -297,19 +297,19 @@ bool ParseYearRange(bool zdump, const std::string& args,
   return false;
 }
 
-int main(int argc, char** argv) {
+int main(int argc, const char** argv) {
   const char* argv0 = (argc > 0) ? (argc--, *argv++) : (argc = 0, "time_tool");
   const std::string prog = Basename(argv0);
 
   // Escape arguments that look like negative offsets so that they
   // don't look like flags.
+  std::vector<std::string> eargs;
   for (int i = 0; i < argc; ++i) {
-    if (strcmp(argv[i], "--") == 0) break;
+    if (std::strcmp(argv[i], "--") == 0) break;
     if (LooksLikeNegOffset(argv[i])) {
-      char* buf = new char[strlen(argv[i] + 2)];
-      buf[0] = ' ';  // will later be ignorned
-      strcpy(buf + 1, argv[i]);
-      argv[i] = buf;
+      eargs.push_back(" ");  // space will later be ignorned
+      eargs.back().append(argv[i]);
+      argv[i] = eargs.back().c_str();
     }
   }
 
@@ -362,27 +362,27 @@ int main(int argc, char** argv) {
         ++optind;
         break;
       }
-      if (strcmp(opt, "tz") == 0) {
+      if (std::strcmp(opt, "tz") == 0) {
         if (optind + 1 == argc) {
           std::cerr << argv0 << ": option '--tz' requires an argument\n";
           ++opterr;
         } else {
           zones = argv[++optind];
         }
-      } else if (strncmp(opt, "tz=", 3) == 0) {
+      } else if (std::strncmp(opt, "tz=", 3) == 0) {
         zones = opt + 3;
-      } else if (strcmp(opt, "fmt") == 0) {
+      } else if (std::strcmp(opt, "fmt") == 0) {
         if (optind + 1 == argc) {
           std::cerr << argv0 << ": option '--fmt' requires an argument\n";
           ++opterr;
         } else {
           fmt = argv[++optind];
         }
-      } else if (strncmp(opt, "fmt=", 4) == 0) {
+      } else if (std::strncmp(opt, "fmt=", 4) == 0) {
         fmt = opt + 4;
-      } else if (strcmp(opt, "zdump") == 0) {
+      } else if (std::strcmp(opt, "zdump") == 0) {
         zdump = true;
-      } else if (strcmp(opt, "zone_dump") == 0) {
+      } else if (std::strcmp(opt, "zone_dump") == 0) {
         zone_dump = true;
       } else {
         std::cerr << argv0 << ": unrecognized option '--" << opt << "'\n";

--- a/src/time_zone_fixed.cc
+++ b/src/time_zone_fixed.cc
@@ -25,7 +25,7 @@ namespace cctz {
 namespace {
 
 // The prefix used for the internal names of fixed-offset zones.
-const char kFixedOffsetPrefix[] = "Fixed/UTC";
+const char kFixedZonePrefix[] = "Fixed/UTC";
 
 const char kDigits[] = "0123456789";
 
@@ -53,11 +53,11 @@ bool FixedOffsetFromName(const std::string& name, seconds* offset) {
     return true;
   }
 
-  const std::size_t prefix_len = sizeof(kFixedOffsetPrefix) - 1;
-  const char* const ep = kFixedOffsetPrefix + prefix_len;
+  const std::size_t prefix_len = sizeof(kFixedZonePrefix) - 1;
+  const char* const ep = kFixedZonePrefix + prefix_len;
   if (name.size() != prefix_len + 9)  // <prefix>+99:99:99
     return false;
-  if (!std::equal(kFixedOffsetPrefix, ep, name.begin()))
+  if (!std::equal(kFixedZonePrefix, ep, name.begin()))
     return false;
   const char* np = name.data() + prefix_len;
   if (np[0] != '+' && np[0] != '-')
@@ -100,9 +100,9 @@ std::string FixedOffsetToName(const seconds& offset) {
   }
   int hours = minutes / 60;
   minutes %= 60;
-  char buf[sizeof(kFixedOffsetPrefix) - 1 + sizeof("-24:00:00")];
-  std::strcpy(buf, kFixedOffsetPrefix);
-  char* ep = buf + sizeof(kFixedOffsetPrefix) - 1;
+  const std::size_t prefix_len = sizeof(kFixedZonePrefix) - 1;
+  char buf[prefix_len + sizeof("-24:00:00")];
+  char* ep = std::copy(kFixedZonePrefix, kFixedZonePrefix + prefix_len, buf);
   *ep++ = sign;
   ep = Format02d(ep, hours);
   *ep++ = ':';
@@ -116,7 +116,7 @@ std::string FixedOffsetToName(const seconds& offset) {
 
 std::string FixedOffsetToAbbr(const seconds& offset) {
   std::string abbr = FixedOffsetToName(offset);
-  const std::size_t prefix_len = sizeof(kFixedOffsetPrefix) - 1;
+  const std::size_t prefix_len = sizeof(kFixedZonePrefix) - 1;
   if (abbr.size() == prefix_len + 9) {         // <prefix>+99:99:99
     abbr.erase(0, prefix_len);                 // +99:99:99
     abbr.erase(6, 1);                          // +99:9999


### PR DESCRIPTION
MSVC emits a couple of "C4496 error: strcpy function my be unsafe"
warnings, so, even though the code is actually safe, we tweak things
to avoid strcpy().

Also fully qualify some \<cstring\> calls in time_tool.cc.

Fixed #106 .