### PR TITLE
Make use of strptime POSIX-compliant

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -28,6 +28,13 @@ config_setting(
     ],
 )
 
+config_setting(
+    name = "windows",
+    constraint_values = [
+        "@bazel_tools//platforms:windows",
+    ],
+)
+
 ### libraries
 
 cc_library(
@@ -65,6 +72,15 @@ cc_library(
         "include/cctz/time_zone.h",
         "include/cctz/zone_info_source.h",
     ],
+    copts = select({
+        "//:windows": [],
+        "//conditions:default": [
+            # Assume all non-windows platforms have strptime.
+            "-DHAS_STRPTIME=1",
+            # Include strptime from time.h.
+            "-D_XOPEN_SOURCE=700",
+        ],
+    }),
     includes = ["include"],
     linkopts = select({
         "//:osx": [

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,10 @@ set_target_properties(cctz PROPERTIES
 target_link_libraries(cctz PUBLIC $<$<PLATFORM_ID:Darwin>:${CoreFoundation}>)  
 add_library(cctz::cctz ALIAS cctz)
 
+if (NOT WIN32)
+  target_compile_options(cctz PRIVATE -DHAS_STRPTIME=1 -D_XOPEN_SOURCE=700)
+endif()
+
 if (BUILD_TOOLS)
   add_executable(time_tool src/time_tool.cc)
   cctz_target_set_cxx_standard(time_tool)

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,11 @@ LDFLAGS ?= -O3
 PREFIX ?= /usr/local
 DESTDIR ?=
 
+# Assume non-Windows platforms support strptime.
+ifneq ($(OS),Windows_NT)
+	CXXFLAGS += -DHAS_STRPTIME=1 -D_XOPEN_SOURCE=700
+endif
+
 # possible support for googletest
 ## TESTS = civil_time_test time_zone_lookup_test time_zone_format_test
 ## TEST_FLAGS = ...

--- a/src/time_zone_format.cc
+++ b/src/time_zone_format.cc
@@ -12,12 +12,6 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-#if !defined(HAS_STRPTIME)
-# if !defined(_MSC_VER) && !defined(__MINGW32__)
-#  define HAS_STRPTIME 1  // assume everyone has strptime() except windows
-# endif
-#endif
-
 #include "cctz/time_zone.h"
 
 #include <cctype>


### PR DESCRIPTION
Using #define before #include is considered bad C++ practice, so the
preprocessor definitions are moved to BUILD.

Reasoning from marmstrong@ on the Google C++ core libraries team: ""I [think] the approach of setting defines before #include is not good for C++.  The approach tends to break C++ modules (go/modules) and, less importantly, breaks clang-format's management of the include blocks in code.  It is also good to support moving code from .cc files to .h files (to support inline and template functions)."

Signed-off-by: Dionna Glaze <dionnaglaze@google.com>