### PR TITLE
Define _XOPEN_SOURCE to import strptime

### DIFF
--- a/src/time_zone_format.cc
+++ b/src/time_zone_format.cc
@@ -18,7 +18,17 @@
 # endif
 #endif
 
+#if defined(HAS_STRPTIME) && HAS_STRPTIME
+# if !defined(_XOPEN_SOURCE)
+#  define _XOPEN_SOURCE  // Definedness suffices for strptime.
+# endif
+#endif
+
 #include "cctz/time_zone.h"
+
+// Include time.h directly since, by C++ standards, ctime doesn't have to
+// declare strptime.
+#include <time.h>
 
 #include <cctype>
 #include <chrono>


### PR DESCRIPTION
POSIX standards require _XOPEN_SOURCE to be defined with any value to
import strptime from time.h. Since the C++ standard doesn't specify
strptime, ctime does not have to be implemented with #include <time.h>.
Therefore, this change adds the include directly.

This PR is an alternative to https://github.com/google/cctz/pull/114