### PR TITLE
Allow get_weekday() and get_yearday() to take all civil-time types

### DIFF
--- a/include/cctz/civil_time.h
+++ b/include/cctz/civil_time.h
@@ -277,7 +277,7 @@ using civil_second = detail::civil_second;
 //
 using detail::weekday;
 
-// Returns the weekday for the given civil_day.
+// Returns the weekday for the given civil-time value.
 //
 //   civil_day a(2015, 8, 13);
 //   weekday wd = get_weekday(a);  // wd == weekday::thursday
@@ -311,7 +311,7 @@ using detail::get_weekday;
 using detail::next_weekday;
 using detail::prev_weekday;
 
-// Returns the day-of-year for the given civil_day.
+// Returns the day-of-year for the given civil-time value.
 //
 //   civil_day a(2015, 1, 1);
 //   int yd_jan_1 = get_yearday(a);   // yd_jan_1 = 1

--- a/include/cctz/civil_time_detail.h
+++ b/include/cctz/civil_time_detail.h
@@ -497,7 +497,8 @@ enum class weekday {
   sunday,
 };
 
-CONSTEXPR_F weekday get_weekday(const civil_day& cd) noexcept {
+template <typename T>
+CONSTEXPR_F weekday get_weekday(const civil_time<T>& ct) noexcept {
   CONSTEXPR_D weekday k_weekday_by_mon_off[13] = {
       weekday::monday,    weekday::tuesday,  weekday::wednesday,
       weekday::thursday,  weekday::friday,   weekday::saturday,
@@ -508,9 +509,9 @@ CONSTEXPR_F weekday get_weekday(const civil_day& cd) noexcept {
   CONSTEXPR_D int k_weekday_offsets[1 + 12] = {
       -1, 0, 3, 2, 5, 0, 3, 5, 1, 4, 6, 2, 4,
   };
-  year_t wd = 2400 + (cd.year() % 400) - (cd.month() < 3);
+  year_t wd = 2400 + (ct.year() % 400) - (ct.month() < 3);
   wd += wd / 4 - wd / 100 + wd / 400;
-  wd += k_weekday_offsets[cd.month()] + cd.day();
+  wd += k_weekday_offsets[ct.month()] + ct.day();
   return k_weekday_by_mon_off[wd % 7 + 6];
 }
 
@@ -556,12 +557,13 @@ CONSTEXPR_F civil_day prev_weekday(civil_day cd, weekday wd) noexcept {
   }
 }
 
-CONSTEXPR_F int get_yearday(const civil_day& cd) noexcept {
+template <typename T>
+CONSTEXPR_F int get_yearday(const civil_time<T>& ct) noexcept {
   CONSTEXPR_D int k_month_offsets[1 + 12] = {
       -1, 0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334,
   };
-  const int feb29 = (cd.month() > 2 && impl::is_leap_year(cd.year()));
-  return k_month_offsets[cd.month()] + feb29 + cd.day();
+  const int feb29 = (ct.month() > 2 && impl::is_leap_year(ct.year()));
+  return k_month_offsets[ct.month()] + feb29 + ct.day();
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/src/civil_time_test.cc
+++ b/src/civil_time_test.cc
@@ -819,6 +819,8 @@ TEST(CivilTime, Properties) {
   EXPECT_EQ(4, ss.hour());
   EXPECT_EQ(5, ss.minute());
   EXPECT_EQ(6, ss.second());
+  EXPECT_EQ(weekday::tuesday, get_weekday(ss));
+  EXPECT_EQ(34, get_yearday(ss));
 
   civil_minute mm(2015, 2, 3, 4, 5, 6);
   EXPECT_EQ(2015, mm.year());
@@ -827,6 +829,8 @@ TEST(CivilTime, Properties) {
   EXPECT_EQ(4, mm.hour());
   EXPECT_EQ(5, mm.minute());
   EXPECT_EQ(0, mm.second());
+  EXPECT_EQ(weekday::tuesday, get_weekday(mm));
+  EXPECT_EQ(34, get_yearday(mm));
 
   civil_hour hh(2015, 2, 3, 4, 5, 6);
   EXPECT_EQ(2015, hh.year());
@@ -835,6 +839,8 @@ TEST(CivilTime, Properties) {
   EXPECT_EQ(4, hh.hour());
   EXPECT_EQ(0, hh.minute());
   EXPECT_EQ(0, hh.second());
+  EXPECT_EQ(weekday::tuesday, get_weekday(hh));
+  EXPECT_EQ(34, get_yearday(hh));
 
   civil_day d(2015, 2, 3, 4, 5, 6);
   EXPECT_EQ(2015, d.year());
@@ -853,6 +859,8 @@ TEST(CivilTime, Properties) {
   EXPECT_EQ(0, m.hour());
   EXPECT_EQ(0, m.minute());
   EXPECT_EQ(0, m.second());
+  EXPECT_EQ(weekday::sunday, get_weekday(m));
+  EXPECT_EQ(32, get_yearday(m));
 
   civil_year y(2015, 2, 3, 4, 5, 6);
   EXPECT_EQ(2015, y.year());
@@ -861,6 +869,8 @@ TEST(CivilTime, Properties) {
   EXPECT_EQ(0, y.hour());
   EXPECT_EQ(0, y.minute());
   EXPECT_EQ(0, y.second());
+  EXPECT_EQ(weekday::thursday, get_weekday(y));
+  EXPECT_EQ(1, get_yearday(y));
 }
 
 TEST(CivilTime, OutputStream) {

--- a/src/time_tool.cc
+++ b/src/time_tool.cc
@@ -101,10 +101,9 @@ std::string FormatTimeInZone(const std::string& fmt, time_point<seconds> when,
   std::ostringstream oss;
   oss << std::setw(36) << std::left << cctz::format(fmt, when, zone);
   cctz::time_zone::absolute_lookup al = zone.lookup(when);
-  cctz::civil_day cd(al.cs);
-  oss << " [wd=" << WeekDayName(cctz::get_weekday(cd))
+  oss << " [wd=" << WeekDayName(cctz::get_weekday(al.cs))
       << " yd=" << std::setw(3) << std::setfill('0')
-      << std::right << cctz::get_yearday(cd)
+      << std::right << cctz::get_yearday(al.cs)
       << " dst=" << (al.is_dst ? 'T' : 'F')
       << " off=" << std::showpos << al.offset << std::noshowpos << "]";
   return oss.str();
@@ -215,7 +214,7 @@ void ZoneDump(bool zdump, const std::string& fmt, cctz::time_zone zone,
         std::cout << " isdst=" << (al.is_dst ? '1' : '0')
                   << " gmtoff=" << al.offset << "\n";
       } else {
-        const char* wd = WeekDayName(get_weekday(cctz::civil_day(al.cs)));
+        const char* wd = WeekDayName(get_weekday(al.cs));
         std::cout << " [wd=" << wd << " dst=" << (al.is_dst ? 'T' : 'F')
                   << " off=" << al.offset << "]\n";
       }

--- a/src/time_zone_format.cc
+++ b/src/time_zone_format.cc
@@ -80,7 +80,7 @@ std::tm ToTM(const time_zone::absolute_lookup& al) {
     tm.tm_year = static_cast<int>(al.cs.year() - 1900);
   }
 
-  switch (get_weekday(civil_day(al.cs))) {
+  switch (get_weekday(al.cs)) {
     case weekday::sunday:
       tm.tm_wday = 0;
       break;
@@ -103,7 +103,7 @@ std::tm ToTM(const time_zone::absolute_lookup& al) {
       tm.tm_wday = 6;
       break;
   }
-  tm.tm_yday = get_yearday(civil_day(al.cs)) - 1;
+  tm.tm_yday = get_yearday(al.cs) - 1;
   tm.tm_isdst = al.is_dst ? 1 : 0;
   return tm;
 }

--- a/src/time_zone_lookup_test.cc
+++ b/src/time_zone_lookup_test.cc
@@ -832,7 +832,7 @@ TEST(BreakTime, LocalTimeInUTC) {
   const time_zone tz = utc_time_zone();
   const auto tp = chrono::system_clock::from_time_t(0);
   ExpectTime(tp, tz, 1970, 1, 1, 0, 0, 0, 0, false, "UTC");
-  EXPECT_EQ(weekday::thursday, get_weekday(civil_day(convert(tp, tz))));
+  EXPECT_EQ(weekday::thursday, get_weekday(convert(tp, tz)));
 }
 
 TEST(BreakTime, LocalTimeInUTCUnaligned) {
@@ -840,7 +840,7 @@ TEST(BreakTime, LocalTimeInUTCUnaligned) {
   const auto tp =
       chrono::system_clock::from_time_t(0) - chrono::milliseconds(500);
   ExpectTime(tp, tz, 1969, 12, 31, 23, 59, 59, 0, false, "UTC");
-  EXPECT_EQ(weekday::wednesday, get_weekday(civil_day(convert(tp, tz))));
+  EXPECT_EQ(weekday::wednesday, get_weekday(convert(tp, tz)));
 }
 
 TEST(BreakTime, LocalTimePosix) {
@@ -848,7 +848,7 @@ TEST(BreakTime, LocalTimePosix) {
   const time_zone tz = utc_time_zone();
   const auto tp = chrono::system_clock::from_time_t(536457599);
   ExpectTime(tp, tz, 1986, 12, 31, 23, 59, 59, 0, false, "UTC");
-  EXPECT_EQ(weekday::wednesday, get_weekday(civil_day(convert(tp, tz))));
+  EXPECT_EQ(weekday::wednesday, get_weekday(convert(tp, tz)));
 }
 
 TEST(TimeZoneImpl, LocalTimeInFixed) {
@@ -858,28 +858,28 @@ TEST(TimeZoneImpl, LocalTimeInFixed) {
   const auto tp = chrono::system_clock::from_time_t(0);
   ExpectTime(tp, tz, 1969, 12, 31, 15, 26, 13, offset.count(), false,
              "-083347");
-  EXPECT_EQ(weekday::wednesday, get_weekday(civil_day(convert(tp, tz))));
+  EXPECT_EQ(weekday::wednesday, get_weekday(convert(tp, tz)));
 }
 
 TEST(BreakTime, LocalTimeInNewYork) {
   const time_zone tz = LoadZone("America/New_York");
   const auto tp = chrono::system_clock::from_time_t(45);
   ExpectTime(tp, tz, 1969, 12, 31, 19, 0, 45, -5 * 60 * 60, false, "EST");
-  EXPECT_EQ(weekday::wednesday, get_weekday(civil_day(convert(tp, tz))));
+  EXPECT_EQ(weekday::wednesday, get_weekday(convert(tp, tz)));
 }
 
 TEST(BreakTime, LocalTimeInMTV) {
   const time_zone tz = LoadZone("America/Los_Angeles");
   const auto tp = chrono::system_clock::from_time_t(1380855729);
   ExpectTime(tp, tz, 2013, 10, 3, 20, 2, 9, -7 * 60 * 60, true, "PDT");
-  EXPECT_EQ(weekday::thursday, get_weekday(civil_day(convert(tp, tz))));
+  EXPECT_EQ(weekday::thursday, get_weekday(convert(tp, tz)));
 }
 
 TEST(BreakTime, LocalTimeInSydney) {
   const time_zone tz = LoadZone("Australia/Sydney");
   const auto tp = chrono::system_clock::from_time_t(90);
   ExpectTime(tp, tz, 1970, 1, 1, 10, 1, 30, 10 * 60 * 60, false, "AEST");
-  EXPECT_EQ(weekday::thursday, get_weekday(civil_day(convert(tp, tz))));
+  EXPECT_EQ(weekday::thursday, get_weekday(convert(tp, tz)));
 }
 
 TEST(MakeTime, TimePointResolution) {
@@ -1270,10 +1270,10 @@ TEST(TimeZoneEdgeCase, PacificApia) {
   //   1325239200 == Sat, 31 Dec 2011 00:00:00 +1400 (+14)
   auto tp = convert(civil_second(2011, 12, 29, 23, 59, 59), tz);
   ExpectTime(tp, tz, 2011, 12, 29, 23, 59, 59, -10 * 3600, true, "-10");
-  EXPECT_EQ(363, get_yearday(civil_day(convert(tp, tz))));
+  EXPECT_EQ(363, get_yearday(convert(tp, tz)));
   tp += cctz::seconds(1);
   ExpectTime(tp, tz, 2011, 12, 31, 0, 0, 0, 14 * 3600, true, "+14");
-  EXPECT_EQ(365, get_yearday(civil_day(convert(tp, tz))));
+  EXPECT_EQ(365, get_yearday(convert(tp, tz)));
 }
 
 TEST(TimeZoneEdgeCase, AfricaCairo) {
@@ -1395,10 +1395,10 @@ TEST(TimeZoneEdgeCase, NegativeYear) {
   const time_zone tz = utc_time_zone();
   auto tp = convert(civil_second(0, 1, 1, 0, 0, 0), tz);
   ExpectTime(tp, tz, 0, 1, 1, 0, 0, 0, 0 * 3600, false, "UTC");
-  EXPECT_EQ(weekday::saturday, get_weekday(civil_day(convert(tp, tz))));
+  EXPECT_EQ(weekday::saturday, get_weekday(convert(tp, tz)));
   tp -= cctz::seconds(1);
   ExpectTime(tp, tz, -1, 12, 31, 23, 59, 59, 0 * 3600, false, "UTC");
-  EXPECT_EQ(weekday::friday, get_weekday(civil_day(convert(tp, tz))));
+  EXPECT_EQ(weekday::friday, get_weekday(convert(tp, tz)));
 }
 
 TEST(TimeZoneEdgeCase, UTC32bitLimit) {


### PR DESCRIPTION
Previously `get_weekday()` and `get_weekday()` only took a `civil_day`,
but this allowed them to be called with a `civil_year` or `civil_month`
(due to implicit conversions), while preventing them from being
called with a `civil_hour`, `civil_minute`, or `civil_second`, where
those functions actually make much more sense.  So, convert them
to template functions that accept all civil-time types.