### PR TITLE
Avoid a "-Wshadow-uncaptured-local" warning

### DIFF
--- a/src/time_zone_info.cc
+++ b/src/time_zone_info.cc
@@ -503,9 +503,9 @@ bool TimeZoneInfo::Load(const std::string& name, ZoneInfoSource* zip) {
   if (tzh.tzh_version[0] != '\0') {
     // Snarf up the NL-enclosed future POSIX spec. Note
     // that version '3' files utilize an extended format.
-    auto get_char = [](ZoneInfoSource* zip) -> int {
+    auto get_char = [](ZoneInfoSource* azip) -> int {
       unsigned char ch;  // all non-EOF results are positive
-      return (zip->Read(&ch, 1) == 1) ? ch : EOF;
+      return (azip->Read(&ch, 1) == 1) ? ch : EOF;
     };
     if (get_char(zip) != '\n')
       return false;


### PR DESCRIPTION
Even though there is no shadowing (if the lambda argument wasn't
"zip", using "zip" in the lambda body would be an error), and it
was nice to use the same name, let's quash the warning.  Fixes #117.