### PR TITLE
Set the correct union field for PosixTransition::N

### DIFF
--- a/src/time_zone_posix.cc
+++ b/src/time_zone_posix.cc
@@ -98,9 +98,9 @@ const char* ParseDateTime(const char* p, PosixTransition* res) {
           int weekday = 0;
           if ((p = ParseInt(p + 1, 0, 6, &weekday)) != nullptr) {
             res->date.fmt = PosixTransition::M;
-            res->date.m.month = static_cast<int_fast8_t>(month);
-            res->date.m.week = static_cast<int_fast8_t>(week);
-            res->date.m.weekday = static_cast<int_fast8_t>(weekday);
+            res->date.m.month = static_cast<std::int_fast8_t>(month);
+            res->date.m.week = static_cast<std::int_fast8_t>(week);
+            res->date.m.weekday = static_cast<std::int_fast8_t>(weekday);
           }
         }
       }
@@ -108,13 +108,13 @@ const char* ParseDateTime(const char* p, PosixTransition* res) {
       int day = 0;
       if ((p = ParseInt(p + 1, 1, 365, &day)) != nullptr) {
         res->date.fmt = PosixTransition::J;
-        res->date.j.day = static_cast<int_fast16_t>(day);
+        res->date.j.day = static_cast<std::int_fast16_t>(day);
       }
     } else {
       int day = 0;
       if ((p = ParseInt(p, 0, 365, &day)) != nullptr) {
         res->date.fmt = PosixTransition::N;
-        res->date.j.day = static_cast<int_fast16_t>(day);
+        res->date.n.day = static_cast<std::int_fast16_t>(day);
       }
     }
   }


### PR DESCRIPTION
This wasn't a practical problem because the `N` field is a
direct overlay for the `J` field, but that was just luck.

Also `std` qualify all uses of the `<cstdint>` types.