### PR TITLE
Ensure we don't call destructor for global static time_zone_mutex

### DIFF
--- a/src/time_zone_impl.cc
+++ b/src/time_zone_impl.cc
@@ -31,7 +31,9 @@ using TimeZoneImplByName =
 TimeZoneImplByName* time_zone_map = nullptr;
 
 // Mutual exclusion for time_zone_map.
-std::mutex time_zone_mutex;
+// This mutex is intentionally "leaked" to avoid the static deinitialization
+// order fiasco (std::mutex's destructor is not trivial on many platforms).
+std::mutex* time_zone_mutex = new std::mutex;
 
 }  // namespace
 
@@ -52,7 +54,7 @@ bool time_zone::Impl::LoadTimeZone(const std::string& name, time_zone* tz) {
   // Then check, under a shared lock, whether the time zone has already
   // been loaded. This is the common path. TODO: Move to shared_mutex.
   {
-    std::lock_guard<std::mutex> lock(time_zone_mutex);
+    std::lock_guard<std::mutex> lock(*time_zone_mutex);
     if (time_zone_map != nullptr) {
       TimeZoneImplByName::const_iterator itr = time_zone_map->find(name);
       if (itr != time_zone_map->end()) {
@@ -63,7 +65,7 @@ bool time_zone::Impl::LoadTimeZone(const std::string& name, time_zone* tz) {
   }
 
   // Now check again, under an exclusive lock.
-  std::lock_guard<std::mutex> lock(time_zone_mutex);
+  std::lock_guard<std::mutex> lock(*time_zone_mutex);
   if (time_zone_map == nullptr) time_zone_map = new TimeZoneImplByName;
   const Impl*& impl = (*time_zone_map)[name];
   if (impl == nullptr) {
@@ -82,7 +84,7 @@ bool time_zone::Impl::LoadTimeZone(const std::string& name, time_zone* tz) {
 }
 
 void time_zone::Impl::ClearTimeZoneMapTestOnly() {
-  std::lock_guard<std::mutex> lock(time_zone_mutex);
+  std::lock_guard<std::mutex> lock(*time_zone_mutex);
   if (time_zone_map != nullptr) {
     // Existing time_zone::Impl* entries are in the wild, so we simply
     // leak them.  Future requests will result in reloading the data.


### PR DESCRIPTION
time_zone_impl.cc contains a global static std::mutex to protect the mutable time_zone_map.

On platforms where std::mutex's destructor is non-trivial (see https://bugs.llvm.org/show_bug.cgi?id=27658), the global mutex is at risk of the static deinitialization order fiasco.

This CL fixes the issue by using `new` to move the file-scoped std::mutex onto the heap, intentionally leaking it to avoid the static deinitialization order fiasco.

Tested:
  % bazel test :all
