### PR TITLE
Fix SIOF issue by moving time_zone_mutex into function

### DIFF
--- a/src/time_zone_impl.cc
+++ b/src/time_zone_impl.cc
@@ -31,9 +31,12 @@ using TimeZoneImplByName =
 TimeZoneImplByName* time_zone_map = nullptr;
 
 // Mutual exclusion for time_zone_map.
-// This mutex is intentionally "leaked" to avoid the static deinitialization
-// order fiasco (std::mutex's destructor is not trivial on many platforms).
-std::mutex* time_zone_mutex = new std::mutex;
+std::mutex& TimeZoneMutex() {
+  // This mutex is intentionally "leaked" to avoid the static deinitialization
+  // order fiasco (std::mutex's destructor is not trivial on many platforms).
+  static std::mutex* time_zone_mutex = new std::mutex;
+  return *time_zone_mutex;
+}
 
 }  // namespace
 
@@ -54,7 +57,7 @@ bool time_zone::Impl::LoadTimeZone(const std::string& name, time_zone* tz) {
   // Then check, under a shared lock, whether the time zone has already
   // been loaded. This is the common path. TODO: Move to shared_mutex.
   {
-    std::lock_guard<std::mutex> lock(*time_zone_mutex);
+    std::lock_guard<std::mutex> lock(TimeZoneMutex());
     if (time_zone_map != nullptr) {
       TimeZoneImplByName::const_iterator itr = time_zone_map->find(name);
       if (itr != time_zone_map->end()) {
@@ -65,7 +68,7 @@ bool time_zone::Impl::LoadTimeZone(const std::string& name, time_zone* tz) {
   }
 
   // Now check again, under an exclusive lock.
-  std::lock_guard<std::mutex> lock(*time_zone_mutex);
+  std::lock_guard<std::mutex> lock(TimeZoneMutex());
   if (time_zone_map == nullptr) time_zone_map = new TimeZoneImplByName;
   const Impl*& impl = (*time_zone_map)[name];
   if (impl == nullptr) {
@@ -84,7 +87,7 @@ bool time_zone::Impl::LoadTimeZone(const std::string& name, time_zone* tz) {
 }
 
 void time_zone::Impl::ClearTimeZoneMapTestOnly() {
-  std::lock_guard<std::mutex> lock(*time_zone_mutex);
+  std::lock_guard<std::mutex> lock(TimeZoneMutex());
   if (time_zone_map != nullptr) {
     // Existing time_zone::Impl* entries are in the wild, so we simply
     // leak them.  Future requests will result in reloading the data.


### PR DESCRIPTION
Originally, https://github.com/google/cctz/pull/123 moved time_zone_mutex
into a function to solve both a SDOF issue as well as a performance issue.

The PR was restructured to only fix the SDOF issue, but that
introduced a SIOF issue where time_zone_mutex was moved to a new'd
pointer on the heap instead of a link-time initialized std::mutex.

To resolve the SIOF issue, this PR restores the original behavior of
moving time_zone_mutex into a function. This does introduce an
additional atomic load (or, on MSVC, a TLS access) to check if
the mutex is initialized, but this is not expected to be a hot
code-path since it can potentially hit the disk to load a time zone
definition.

Tested:
  % bazel test :all

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/cctz/124)
<!-- Reviewable:end -->
