### PR TITLE
Load @rules_cc for compatibility with Bazel 1.0

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -12,6 +12,8 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+
 licenses(["notice"])  # Apache License
 
 config_setting(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -15,3 +15,14 @@ http_archive(
     urls = ["https://github.com/google/benchmark/archive/master.zip"],
     strip_prefix = "benchmark-master",
 )
+
+# C++ rules for Bazel.
+http_archive(
+    name = "rules_cc",
+    sha256 = "67412176974bfce3f4cf8bdaff39784a72ed709fc58def599d1f68710b58d68b",
+    strip_prefix = "rules_cc-b7fe9697c0c76ab2fd431a891dbb9a6a32ed7c3e",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_cc/archive/b7fe9697c0c76ab2fd431a891dbb9a6a32ed7c3e.zip",
+        "https://github.com/bazelbuild/rules_cc/archive/b7fe9697c0c76ab2fd431a891dbb9a6a32ed7c3e.zip",
+    ],
+)


### PR DESCRIPTION
Starting with Bazel 1.0 (September 2019), C++ rules will need to be
loaded from the @rules_cc repository. This change adds the required
loads for that.

Pull request for Abseil is
https://github.com/abseil/abseil-cpp/pull/351

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/cctz/125)
<!-- Reviewable:end -->
