### PR TITLE
Defeat leak detectors in ClearTimeZoneMapTestOnly()

### DIFF
--- a/src/time_zone_impl.cc
+++ b/src/time_zone_impl.cc
@@ -14,6 +14,7 @@
 
 #include "time_zone_impl.h"
 
+#include <deque>
 #include <mutex>
 #include <string>
 #include <unordered_map>
@@ -89,8 +90,14 @@ bool time_zone::Impl::LoadTimeZone(const std::string& name, time_zone* tz) {
 void time_zone::Impl::ClearTimeZoneMapTestOnly() {
   std::lock_guard<std::mutex> lock(TimeZoneMutex());
   if (time_zone_map != nullptr) {
-    // Existing time_zone::Impl* entries are in the wild, so we simply
-    // leak them.  Future requests will result in reloading the data.
+    // Existing time_zone::Impl* entries are in the wild, so we can't delete
+    // them. Instead, we move them to a private container, where they are
+    // logically unreachable but not "leaked".  Future requests will result
+    // in reloading the data.
+    static auto* cleared = new std::deque<const time_zone::Impl*>;
+    for (const auto& element : *time_zone_map) {
+      cleared->push_back(element.second);
+    }
     time_zone_map->clear();
   }
 }


### PR DESCRIPTION
Instead of simply forgetting about existing `time_zone::Impl*` entries
in `ClearTimeZoneMapTestOnly()`, move them to a private container,
where they are logically unreachable but not "leaked".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/cctz/129)
<!-- Reviewable:end -->
