### PR TITLE
Disables the zone_info_source extension under the MinGW compiler

### DIFF
--- a/src/zone_info_source.cc
+++ b/src/zone_info_source.cc
@@ -43,10 +43,13 @@ std::unique_ptr<cctz::ZoneInfoSource> DefaultFactory(
 #if !defined(__has_attribute)
 #define __has_attribute(x) 0
 #endif
-#if __has_attribute(weak) || defined(__GNUC__)
+// MinGW is GCC on Windows, so while it asserts __has_attribute(weak), the
+// Windows linker cannot handle that. Nor does the MinGW compiler know how to
+// pass "#pragma comment(linker, ...)" to the Windows linker.
+#if (__has_attribute(weak) || defined(__GNUC__)) && !defined(__MINGW32__)
 ZoneInfoSourceFactory zone_info_source_factory
     __attribute__((weak)) = DefaultFactory;
-#elif defined(_MSC_VER) && !defined(_LIBCPP_VERSION)
+#elif defined(_MSC_VER) && !defined(__MINGW32__) && !defined(_LIBCPP_VERSION)
 extern ZoneInfoSourceFactory zone_info_source_factory;
 extern ZoneInfoSourceFactory default_factory;
 ZoneInfoSourceFactory default_factory = DefaultFactory;


### PR DESCRIPTION
MinGW is GCC on Windows, so while it asserts __has_attribute(weak),
the Windows linker cannot handle that. Nor does the MinGW compiler
know how to pass "#pragma comment(linker, ...)" to the Windows linker.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/cctz/130)
<!-- Reviewable:end -->
