### PR TITLE
check for year overflow when parsing %U/%W conversions

### DIFF
--- a/src/time_zone_format.cc
+++ b/src/time_zone_format.cc
@@ -649,14 +649,23 @@ const char* ParseTM(const char* dp, const char* fmt, std::tm* tm) {
 }
 
 // Sets year, tm_mon and tm_mday given the year, week_num, and tm_wday,
-// and the day on which weeks are defined to start.
-void FromWeek(int week_num, weekday week_start, year_t* year, std::tm* tm) {
+// and the day on which weeks are defined to start.  Returns false if year
+// would need to move outside its bounds.
+bool FromWeek(int week_num, weekday week_start, year_t* year, std::tm* tm) {
   const civil_year y(*year % 400);
   civil_day cd = prev_weekday(y, week_start);  // week 0
   cd = next_weekday(cd - 1, FromTmWday(tm->tm_wday)) + (week_num * 7);
-  *year += cd.year() - y.year();
+  if (const year_t shift = cd.year() - y.year()) {
+    if (shift > 0) {
+      if (*year > std::numeric_limits<year_t>::max() - shift) return false;
+    } else {
+      if (*year < std::numeric_limits<year_t>::min() - shift) return false;
+    }
+    *year += shift;
+  }
   tm->tm_mon = cd.month() - 1;
   tm->tm_mday = cd.day();
+  return true;
 }
 
 }  // namespace
@@ -961,7 +970,12 @@ bool parse(const std::string& format, const std::string& input,
   }
 
   // Compute year, tm.tm_mon and tm.tm_mday if we parsed a week number.
-  if (week_num != -1) FromWeek(week_num, week_start, &year, &tm);
+  if (week_num != -1) {
+    if (!FromWeek(week_num, week_start, &year, &tm)) {
+      if (err != nullptr) *err = "Out-of-range field";
+      return false;
+    }
+  }
 
   const int month = tm.tm_mon + 1;
   civil_second cs(year, month, tm.tm_mday, tm.tm_hour, tm.tm_min, tm.tm_sec);

--- a/src/time_zone_format_test.cc
+++ b/src/time_zone_format_test.cc
@@ -1475,6 +1475,11 @@ TEST(Parse, WeekYearShift) {
   EXPECT_EQ(exp, tp);
   EXPECT_TRUE(parse("%Y-%W-%w", "2020-52-5", utc, &tp));
   EXPECT_EQ(exp, tp);
+
+  // Slipping into the previous/following calendar years should fail when
+  // we're already at the extremes.
+  EXPECT_FALSE(parse("%Y-%U-%u", "-9223372036854775808-0-7", utc, &tp));
+  EXPECT_FALSE(parse("%Y-%U-%u", "9223372036854775807-53-7", utc, &tp));
 }
 
 TEST(Parse, MaxRange) {


### PR DESCRIPTION
Parsing %U/%W conversions with week values in {0, 52, 53} can
slip into the previous/following calendar years, so fail the parse if
the final year value cannot be represented.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/cctz/153)
<!-- Reviewable:end -->
