### PR TITLE
handle "slim" TZif files in TimeZoneInfo::ExtendTransitions()

### DIFF
--- a/src/time_zone_info.h
+++ b/src/time_zone_info.h
@@ -92,15 +92,12 @@ class TimeZoneInfo : public TimeZoneIf {
     std::size_t DataLength(std::size_t time_len) const;
   };
 
-  void CheckTransition(const std::string& name, const TransitionType& tt,
-                       std::int_fast32_t offset, bool is_dst,
-                       const std::string& abbr) const;
   bool EquivTransitions(std::uint_fast8_t tt1_index,
                         std::uint_fast8_t tt2_index) const;
-  void ExtendTransitions(const std::string& name, const Header& hdr);
+  bool ExtendTransitions();
 
   bool ResetToBuiltinUTC(const seconds& offset);
-  bool Load(const std::string& name, ZoneInfoSource* zip);
+  bool Load(ZoneInfoSource* zip);
 
   // Helpers for BreakTime() and MakeTime().
   time_zone::absolute_lookup LocalTime(std::int_fast64_t unix_time,


### PR DESCRIPTION
In an upcoming release of https://github.com/eggert/tz (probably
2020b), the default value for zic's "-b" (bloat) option will change
from "fat" to "slim". This makes the TZif files smaller by omitting
transitions that were ostensibly only there to work around potential
bugs or incompatibilities in old readers.

TimeZoneInfo::ExtendTransitions() depended on the shape of those
transitions when using the POSIX TZ string to handle instants after
the last transition in the file.

So, update ExtendTransitions() to deal with both TZif varieties.
In the process, remove the logging that tried to alert the user when
those old transition-shape assumptions were found not to hold.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/cctz/154)
<!-- Reviewable:end -->
