### PR TITLE
handle "slim" TZif files in TimeZoneInfo::ExtendTransitions()

### DIFF
--- a/src/time_zone_info.h
+++ b/src/time_zone_info.h
@@ -92,6 +92,8 @@ class TimeZoneInfo : public TimeZoneIf {
     std::size_t DataLength(std::size_t time_len) const;
   };
 
+  bool GetTransitionType(std::int_fast32_t utc_offset, bool is_dst,
+                         const std::string& abbr, std::uint_fast8_t* index);
   bool EquivTransitions(std::uint_fast8_t tt1_index,
                         std::uint_fast8_t tt2_index) const;
   bool ExtendTransitions();


### PR DESCRIPTION
Two zones, America/Indiana/Petersburg and America/North_Dakota/Beulah,
do not include a transition type matching their future DST rule in the
"slim" zic output. So, we must create one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/cctz/155)
<!-- Reviewable:end -->
