### PR TITLE
Removes license comment

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -14,7 +14,7 @@
 
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 
-licenses(["notice"])  # Apache License
+licenses(["notice"])
 
 config_setting(
     name = "osx",


### PR DESCRIPTION
The BUILD file is not the source of truth for the license

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/cctz/160)
<!-- Reviewable:end -->
