### PR TITLE
[Feature] Use included zoneinfo on Windows when using Bazel

### DIFF
--- a/src/time_zone_info.cc
+++ b/src/time_zone_info.cc
@@ -44,6 +44,10 @@
 #include <sstream>
 #include <string>
 
+#if HAVE_CCTZ_CONFIG_H
+#include "cctz/config.h"
+#endif
+
 #include "cctz/civil_time.h"
 #include "time_zone_fixed.h"
 #include "time_zone_posix.h"
@@ -642,16 +646,20 @@ std::unique_ptr<ZoneInfoSource> FileZoneInfoSource::Open(
   std::string path;
   if (pos == name.size() || name[pos] != '/') {
     const char* tzdir = "/usr/share/zoneinfo";
-    char* tzdir_env = nullptr;
+#if defined(CCTZ_TZDIR)
+    const char *tzdir_env = CCTZ_TZDIR;
+#else
+    char *tzdir_env = nullptr;
 #if defined(_MSC_VER)
     _dupenv_s(&tzdir_env, nullptr, "TZDIR");
 #else
     tzdir_env = std::getenv("TZDIR");
 #endif
+#endif
     if (tzdir_env && *tzdir_env) tzdir = tzdir_env;
     path += tzdir;
     path += '/';
-#if defined(_MSC_VER)
+#if !defined(CCTZ_TZDIR) && defined(_MSC_VER)
     free(tzdir_env);
 #endif
   }


### PR DESCRIPTION
Namaste,

The Bazel build on Windows is currently broken by default—it requires me to define the `$TZDIR` environment variable, which is kind of unwieldy to do on Windows because each shell/subsystem has its own syntax/method. The repository includes the latest `zoneinfo` files already, so I'm wondering whether we could use them on Windows with Bazel by default.

With the accompanying series of patches, I've attempted to use a Bazel-generated configuration header—namely, `include/cctz/config.h`—to define `CCTZ_TZDIR` by setting it to the location of the included `zoneinfo` database instead therefore making it less of a concern for the user of the library. I believe using this approach would make it easier to work with `cctz` on Windows when using Bazel even if the user doesn't define the `$TZDIR` environment variable. It also makes using `cctz` appear the same regardless of platform.  

Additionally, with this approach, if you define `USE_CCTZ_TZDIR=1` it should use the included `zoneinfo` files for any platform. Currently, I've configured it for only Windows.

I've also exposed the unit tests within the `BUILD` file so that dependents can run our tests alongside theirs and detect problems early for their platforms—`bazel test @com_google_cctz//:all` doesn't work.

I've tested this patch on 64-bit versions of:
* Ubuntu 20.04/WSL2 (GCC 10)
* ClearLinux (GCC 10)
* Mac OS X 10.15.6 (Clang 10)
* Mac OS 11 beta (Clang 12)
* Windows 10 (Microsoft C/C++ compiler version 19.27.29111 [VS 2019]).

What do you folks think?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/cctz/161)
<!-- Reviewable:end -->
