### PR TITLE
Use libc:localtime for local_time_zone on Emscripten instead of hitting the filesystem.

### DIFF
--- a/src/time_zone_lookup.cc
+++ b/src/time_zone_lookup.cc
@@ -139,6 +139,11 @@ time_zone local_time_zone() {
   }
   CFRelease(tz_default);
 #endif
+#if defined(__EMSCRIPTEN__)
+  // Emscripten doesn't necessarily link in filesystem support nor have zoneinfo
+  // files available, so use libc (which does work) instead.
+  zone = "libc:localtime";
+#endif
 
   // Allow ${TZ} to override to default zone.
   char* tz_env = nullptr;


### PR DESCRIPTION
Emscripten doesn't necessarily link in filesystem support nor have zoneinfo files available, but its libc does know the local time zone.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/cctz/162)
<!-- Reviewable:end -->
