### PR TITLE
Adds a missing linker flag (-lm) to allow building cctz on FreeBSD.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -24,6 +24,13 @@ config_setting(
 )
 
 config_setting(
+    name = "openbsd",
+    constraint_values = [
+        "@bazel_tools//platforms:openbsd",
+    ],
+)
+
+config_setting(
     name = "osx",
     constraint_values = [
         "@bazel_tools//platforms:osx",
@@ -49,6 +56,10 @@ cc_library(
     textual_hdrs = ["include/cctz/civil_time_detail.h"],
     visibility = ["//visibility:public"],
 )
+
+BSD_LINKOPTS = [
+    "-lm",
+]
 
 cc_library(
     name = "time_zone",
@@ -82,9 +93,8 @@ cc_library(
         "//:ios": [
             "-framework Foundation",
         ],
-        "//:freebsd": [
-            "-lm",
-        ],
+        "//:freebsd": BSD_LINKOPTS,
+        "//:openbsd": BSD_LINKOPTS,
         "//conditions:default": [],
     }),
     visibility = ["//visibility:public"],

--- a/BUILD
+++ b/BUILD
@@ -17,6 +17,13 @@ load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 licenses(["notice"])  # Apache License
 
 config_setting(
+    name = "freebsd",
+    constraint_values = [
+        "@bazel_tools//platforms:freebsd",
+    ],
+)
+
+config_setting(
     name = "osx",
     constraint_values = [
         "@bazel_tools//platforms:osx",
@@ -74,6 +81,9 @@ cc_library(
         ],
         "//:ios": [
             "-framework Foundation",
+        ],
+        "//:freebsd": [
+            "-lm",
         ],
         "//conditions:default": [],
     }),


### PR DESCRIPTION
Fixes #163 when building cctz on FreeBSD.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/cctz/164)
<!-- Reviewable:end -->
