### PR TITLE
Disable a "libc:UTC" test expectation that fails on BSD systems

### DIFF
--- a/src/time_zone_lookup_test.cc
+++ b/src/time_zone_lookup_test.cc
@@ -1003,7 +1003,11 @@ TEST(MakeTime, SysSecondsLimits) {
     const time_zone cut = LoadZone("libc:UTC");
     const year_t max_tm_year = year_t{std::numeric_limits<int>::max()} + 1900;
     tp = convert(civil_second(max_tm_year, 12, 31, 23, 59, 59), cut);
+#if defined(__FreeBSD__) || defined(__OpenBSD__)
+    // The BSD gmtime_r() fails on extreme positive tm_year values.
+#else
     EXPECT_EQ("2147485547-12-31T23:59:59+00:00", format(RFC3339, tp, cut));
+#endif
     const year_t min_tm_year = year_t{std::numeric_limits<int>::min()} + 1900;
     tp = convert(civil_second(min_tm_year, 1, 1, 0, 0, 0), cut);
     EXPECT_EQ("-2147481748-01-01T00:00:00+00:00", format(RFC3339, tp, cut));


### PR DESCRIPTION
MakeTime.SysSecondsLimits currently assumes that `gmtime_r()` can
handle (64-bit) `time_t` inputs that exercise the full range of the
`tm_year` field on output.  This assumption does not appear to hold
on BSD systems.

In particular, the test assumes `gmtime_t()`, given a `time_t` value
of 67768036191676799, will produce the "largest possible" `struct tm`,
`{tm_year=2147483647 tm_mon=11 tm_mday=31 tm_hour=23 tm_min=59 tm_sec=59}`.
On BSD systems `gmtime_t()` instead returns NULL, which then causes
CCTZ to return a saturated `civil_second` from `time_zone::lookup()`.

So, let's simply omit that expectation on FreeBSD and OpenBSD systems.

Fixes #165.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/cctz/166)
<!-- Reviewable:end -->
