### PR TITLE
Tie google/googletest and google/benchmark to a recent release

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5,15 +5,17 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # GoogleTest/GoogleMock framework. Used by most unit-tests.
 http_archive(
     name = "com_google_googletest",
-    urls = ["https://github.com/google/googletest/archive/master.zip"],
-    strip_prefix = "googletest-master",
+    sha256 = "94c634d499558a76fa649edb13721dce6e98fb1e7018dfaeba3cd7a083945e91",
+    strip_prefix = "googletest-release-1.10.0",
+    urls = ["https://github.com/google/googletest/archive/release-1.10.0.zip"],
 )
 
 # Google Benchmark library.
 http_archive(
     name = "com_github_google_benchmark",
-    urls = ["https://github.com/google/benchmark/archive/master.zip"],
-    strip_prefix = "benchmark-master",
+    sha256 = "3e266b49f73ee08625837ea5b1fabc4056b7f5e809b29c49670527326f4f4379",
+    strip_prefix = "benchmark-1.5.1",
+    urls = ["https://github.com/google/benchmark/archive/v1.5.1.zip"],
 )
 
 # C++ rules for Bazel.


### PR DESCRIPTION
Avoid using the head releases in favor of a named release in
the interest of stability.  We'll have to update occasionally,
but that's OK.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/cctz/168)
<!-- Reviewable:end -->
