### PR TITLE
Fix tm_gmtoff build failure on AIX

### DIFF
--- a/src/time_zone_libc.cc
+++ b/src/time_zone_libc.cc
@@ -26,6 +26,12 @@
 #include "cctz/civil_time.h"
 #include "cctz/time_zone.h"
 
+#if defined(_AIX)
+extern "C" {
+  extern long altzone;
+}
+#endif
+
 namespace cctz {
 
 namespace {
@@ -40,7 +46,7 @@ auto tm_zone(const std::tm& tm) -> decltype(_tzname[0]) {
   const bool is_dst = tm.tm_isdst > 0;
   return _tzname[is_dst];
 }
-#elif defined(__sun)
+#elif defined(__sun) || defined(_AIX)
 // Uses the globals: 'timezone', 'altzone' and 'tzname'.
 auto tm_gmtoff(const std::tm& tm) -> decltype(timezone) {
   const bool is_dst = tm.tm_isdst > 0;


### PR DESCRIPTION
AIX does not provide a `struct tm` field for timezone offset, just like
Solaris so the existing code for that platform can be reused on AIX.
Unfortunately, AIX does not define the `altzone` variable in any header
file so a definition must be defined in this file.

Fixes #176

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/cctz/177)
<!-- Reviewable:end -->
