### PR TITLE
add initial fuzzer for integration with OSS-Fuzz.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,16 @@ if (BUILD_TESTING)
   )
 endif()
 
+if (BUILD_FUZZ)
+  if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    add_compile_options(-fsanitize=fuzzer-no-link)
+    add_link_options(-fsanitize=fuzzer-no-link)
+  else()
+    message( SEND_ERROR "You must use clang++ for compiling fuzzers" )
+  endif()
+endif()
+
+
 # Starting from CMake >= 3.1, if a specific standard is required,
 # it can be set from the command line with:
 #     cmake -DCMAKE_CXX_STANDARD=[11|14|17]
@@ -102,6 +112,13 @@ set_target_properties(cctz PROPERTIES
   )
 target_link_libraries(cctz PUBLIC $<$<PLATFORM_ID:Darwin>:${CoreFoundation}>)  
 add_library(cctz::cctz ALIAS cctz)
+
+if (BUILD_FUZZ)
+  add_executable(cctz_fuzz src/cctz_fuzz.cc)
+  cctz_target_set_cxx_standard(cctz_fuzz)
+  target_link_libraries(cctz_fuzz cctz::cctz)
+  target_link_libraries(cctz_fuzz -fsanitize=fuzzer)
+endif()
 
 if (BUILD_TOOLS)
   add_executable(time_tool src/time_tool.cc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ if (BUILD_FUZZ)
     add_compile_options(-fsanitize=fuzzer-no-link)
     add_link_options(-fsanitize=fuzzer-no-link)
   else()
-    message( SEND_ERROR "You must use clang++ for compiling fuzzers" )
+    message(SEND_ERROR "You must use clang++ for compiling fuzzers")
   endif()
 endif()
 

--- a/src/cctz_fuzz.cc
+++ b/src/cctz_fuzz.cc
@@ -1,0 +1,47 @@
+/* Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <fuzzer/FuzzedDataProvider.h>
+
+#include <iostream>
+#include <string>
+
+#include "cctz/civil_time.h"
+#include "cctz/time_zone.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+	FuzzedDataProvider fuzzed_data(data, size);
+
+	cctz::time_zone lax;
+	std::string tz = fuzzed_data.ConsumeRandomLengthString();
+	if (load_time_zone(tz, &lax)) {
+		std::chrono::system_clock::time_point tp;
+		std::string date_format = fuzzed_data.ConsumeRandomLengthString();
+		std::string parse_format = fuzzed_data.ConsumeRandomLengthString();
+		cctz::parse(parse_format, date_format, lax, &tp);
+
+		const auto t1 = cctz::convert(cctz::civil_second(
+				fuzzed_data.ConsumeIntegral<uint32_t>(),
+				fuzzed_data.ConsumeIntegral<uint32_t>(),
+				fuzzed_data.ConsumeIntegral<uint32_t>(),
+				fuzzed_data.ConsumeIntegral<uint32_t>(),
+				fuzzed_data.ConsumeIntegral<uint32_t>(),
+				fuzzed_data.ConsumeIntegral<uint32_t>()), lax);
+		std::string format = fuzzed_data.ConsumeRandomLengthString();
+		cctz::format(format, t1, lax);
+	}
+
+	return 0;
+}

--- a/src/cctz_fuzz.cc
+++ b/src/cctz_fuzz.cc
@@ -14,9 +14,6 @@
 
 #include <fuzzer/FuzzedDataProvider.h>
 
-#include <iostream>
-#include <string>
-
 #include <string>
 
 #include "cctz/civil_time.h"

--- a/src/cctz_fuzz.cc
+++ b/src/cctz_fuzz.cc
@@ -41,7 +41,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
                 fuzzed_data.ConsumeIntegral<std::uint64_t>(),
                 fuzzed_data.ConsumeIntegral<std::uint64_t>()), tz);
         std::string format = fuzzed_data.ConsumeRandomLengthString();
-        cctz::format(format, when, tz);
+        std::string formatted = cctz::format(format, when, tz);
+        cctz::parse(format, formatted, tz, &tp);
     }
 
     return 0;

--- a/src/cctz_fuzz.cc
+++ b/src/cctz_fuzz.cc
@@ -1,47 +1,48 @@
-/* Copyright 2020 Google LLC
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <fuzzer/FuzzedDataProvider.h>
 
 #include <iostream>
 #include <string>
 
+#include <string>
+
 #include "cctz/civil_time.h"
 #include "cctz/time_zone.h"
 
-extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
-	FuzzedDataProvider fuzzed_data(data, size);
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+    FuzzedDataProvider fuzzed_data(data, size);
 
-	cctz::time_zone lax;
-	std::string tz = fuzzed_data.ConsumeRandomLengthString();
-	if (load_time_zone(tz, &lax)) {
-		std::chrono::system_clock::time_point tp;
-		std::string date_format = fuzzed_data.ConsumeRandomLengthString();
-		std::string parse_format = fuzzed_data.ConsumeRandomLengthString();
-		cctz::parse(parse_format, date_format, lax, &tp);
+    cctz::time_zone tz;
+    std::string tz_string = fuzzed_data.ConsumeRandomLengthString();
+    if (cctz::load_time_zone(tz_string, &tz)) {
+        std::chrono::system_clock::time_point tp;
+        std::string date_format = fuzzed_data.ConsumeRandomLengthString();
+        std::string parse_format = fuzzed_data.ConsumeRandomLengthString();
+        cctz::parse(parse_format, date_format, tz, &tp);
 
-		const auto t1 = cctz::convert(cctz::civil_second(
-				fuzzed_data.ConsumeIntegral<uint32_t>(),
-				fuzzed_data.ConsumeIntegral<uint32_t>(),
-				fuzzed_data.ConsumeIntegral<uint32_t>(),
-				fuzzed_data.ConsumeIntegral<uint32_t>(),
-				fuzzed_data.ConsumeIntegral<uint32_t>(),
-				fuzzed_data.ConsumeIntegral<uint32_t>()), lax);
-		std::string format = fuzzed_data.ConsumeRandomLengthString();
-		cctz::format(format, t1, lax);
-	}
+        const auto when = cctz::convert(cctz::civil_second(
+                fuzzed_data.ConsumeIntegral<std::uint64_t>(),
+                fuzzed_data.ConsumeIntegral<std::uint64_t>(),
+                fuzzed_data.ConsumeIntegral<std::uint64_t>(),
+                fuzzed_data.ConsumeIntegral<std::uint64_t>(),
+                fuzzed_data.ConsumeIntegral<std::uint64_t>(),
+                fuzzed_data.ConsumeIntegral<std::uint64_t>()), tz);
+        std::string format = fuzzed_data.ConsumeRandomLengthString();
+        cctz::format(format, when, tz);
+    }
 
-	return 0;
+    return 0;
 }


### PR DESCRIPTION
Hi maintainers,

It would be nice to have this project fuzzed by way of OSS-Fuzz, which is a service run by Google that performs continuous fuzzing of open source projects. 

Over here: https://github.com/google/oss-fuzz/pull/4806 I have set up the necessary artifacts to get the project integrated. In that PR you also see the fuzzer attached, but it would be nicer to have the fuzzer integrated into the upstream project itself rather than keeping it in OSS-Fuzz - so if this PR gets merged I will remove it from OSS-Fuzz. For integration, the only thing we need email of the maintainers that will be receiving access to bug reports, coverage reports and similar.

If you have any questions you can ask me, but as this is a Google open source project I assume you can reach out internally to @inferno-chromium

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/cctz/178)
<!-- Reviewable:end -->
