### PR TITLE
Add support for cctz::load_time_zone("UTC0", &tz)

### DIFF
--- a/src/time_tool.cc
+++ b/src/time_tool.cc
@@ -249,18 +249,14 @@ bool LooksLikeNegOffset(const char* s) {
 
 std::vector<std::string> StrSplit(char sep, const std::string& s) {
   std::vector<std::string> v;
-  // An empty string value corresponds to an empty vector, not a vector
-  // with a single, empty string.
-  if (!s.empty()) {
-    std::string::size_type pos = 0;
-    for (;;) {
-      std::string::size_type spos = s.find(sep, pos);
-      if (spos == std::string::npos) break;
-      v.push_back(s.substr(pos, spos - pos));
-      pos = spos + 1;
-    }
-    v.push_back(s.substr(pos));
+  std::string::size_type pos = 0;
+  for (;;) {
+    std::string::size_type spos = s.find(sep, pos);
+    if (spos == std::string::npos) break;
+    v.push_back(s.substr(pos, spos - pos));
+    pos = spos + 1;
   }
+  v.push_back(s.substr(pos));
   return v;
 }
 
@@ -313,7 +309,7 @@ int main(int argc, const char** argv) {
   }
 
   // Determine the time zone and other options.
-  std::string zones = "localtime";
+  std::string zones;  // empty means localtime
   std::string fmt = "%Y-%m-%d %H:%M:%S %E*z (%Z)";
   bool zone_dump = (prog == "zone_dump");
   bool zdump = false;  // Use zdump(8) format.
@@ -432,7 +428,9 @@ int main(int argc, const char** argv) {
   for (const std::string& tz : StrSplit(',', zones)) {
     std::cout << leader;
     cctz::time_zone zone;
-    if (!cctz::load_time_zone(tz, &zone)) {
+    if (tz.empty()) {
+      zone = cctz::local_time_zone();
+    } else if (!cctz::load_time_zone(tz, &zone)) {
       std::cerr << tz << ": Unrecognized time zone\n";
       return 1;
     }

--- a/src/time_zone_fixed.cc
+++ b/src/time_zone_fixed.cc
@@ -48,11 +48,9 @@ int Parse02d(const char* p) {
 }  // namespace
 
 bool FixedOffsetFromName(const std::string& name, seconds* offset) {
-  if (name.rfind("UTC", 0, 3) == 0) {
-    if (name.size() == 3 || (name.size() == 4 && name[3] == '0')) {
-      *offset = seconds::zero();  // "UTC" or "UTC0"
-      return true;
-    }
+  if (name == "UTC" || name == "UTC0") {
+    *offset = seconds::zero();
+    return true;
   }
 
   const std::size_t prefix_len = sizeof(kFixedZonePrefix) - 1;

--- a/src/time_zone_fixed.cc
+++ b/src/time_zone_fixed.cc
@@ -48,9 +48,11 @@ int Parse02d(const char* p) {
 }  // namespace
 
 bool FixedOffsetFromName(const std::string& name, seconds* offset) {
-  if (name.compare(0, std::string::npos, "UTC", 3) == 0) {
-    *offset = seconds::zero();
-    return true;
+  if (name.rfind("UTC", 0, 3) == 0) {
+    if (name.size() == 3 || (name.size() == 4 && name[3] == '0')) {
+      *offset = seconds::zero();  // "UTC" or "UTC0"
+      return true;
+    }
   }
 
   const std::size_t prefix_len = sizeof(kFixedZonePrefix) - 1;

--- a/src/time_zone_lookup_test.cc
+++ b/src/time_zone_lookup_test.cc
@@ -714,6 +714,18 @@ TEST(TimeZones, LoadZonesConcurrently) {
   EXPECT_LE(failures.size(), max_failures) << testing::PrintToString(failures);
 }
 
+TEST(TimeZone, UTC) {
+  const time_zone utc = utc_time_zone();
+
+  time_zone loaded_utc;
+  EXPECT_TRUE(load_time_zone("UTC", &loaded_utc));
+  EXPECT_EQ(loaded_utc, utc);
+
+  time_zone loaded_utc0;
+  EXPECT_TRUE(load_time_zone("UTC0", &loaded_utc0));
+  EXPECT_EQ(loaded_utc0, utc);
+}
+
 TEST(TimeZone, NamedTimeZones) {
   const time_zone utc = utc_time_zone();
   EXPECT_EQ("UTC", utc.name());


### PR DESCRIPTION
`cctz::load_time_zone("UTC0", &tz)` now behaves exactly the same as
`cctz::load_time_zone("UTC", &tz)`, allowing `cctz::local_time_zone()`
to "succeed" (i.e., without fallback to "UTC") under `TZ=UTC0`.

This allows for setting `TZ=UTC0` to specify the local timezone as
UTC under both CCTZ and libraries that use POSIX-style `${TZ}` parsing.

Update `time_tool` to use an empty string to request `local_time_zone()`
instead of depending on `load_time_zone("localtime", &tz)` doing the
same thing, which may not work with the configuration of some systems.
This means that `time_tool` now respects `${TZ}`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/cctz/185)
<!-- Reviewable:end -->
