### PR TITLE
Fixes -Wrange-loop-construct warning in GCC 11

### DIFF
--- a/src/time_zone_format_test.cc
+++ b/src/time_zone_format_test.cc
@@ -1129,7 +1129,7 @@ TEST(Parse, ExtendedSeconds) {
   // All %E<prec>S cases are treated the same as %E*S on input.
   auto precisions = {"*", "0", "1",  "2",  "3",  "4",  "5",  "6", "7",
                      "8", "9", "10", "11", "12", "13", "14", "15"};
-  for (const std::string& prec : precisions) {
+  for (const std::string prec : precisions) {
     const std::string fmt = "%E" + prec + "S";
     SCOPED_TRACE(fmt);
     time_point<chrono::nanoseconds> tp = unix_epoch;
@@ -1211,7 +1211,7 @@ TEST(Parse, ExtendedSubeconds) {
   // All %E<prec>f cases are treated the same as %E*f on input.
   auto precisions = {"*", "0", "1",  "2",  "3",  "4",  "5",  "6", "7",
                      "8", "9", "10", "11", "12", "13", "14", "15"};
-  for (const std::string& prec : precisions) {
+  for (const std::string prec : precisions) {
     const std::string fmt = "%E" + prec + "f";
     SCOPED_TRACE(fmt);
     time_point<chrono::nanoseconds> tp = unix_epoch - chrono::seconds(1);


### PR DESCRIPTION
This should be covered by the reference lifetime extension,
but it is a new warning nonetheless.

time_zone_format_test.cc:1138:27: error: loop variable 'prec' of type
'const string&' {aka 'const std::__cxx11::basic_string<char>&'} binds
to a temporary constructed from type 'const char* const'
[-Werror=range-loop-construct]