### PR TITLE
Add basic support for Fuchsia

### DIFF
--- a/src/time_zone_info.cc
+++ b/src/time_zone_info.cc
@@ -43,6 +43,11 @@
 #include <memory>
 #include <sstream>
 #include <string>
+#include <utility>
+
+#if defined(__Fuchsia__)
+#include <fstream>
+#endif
 
 #include "cctz/civil_time.h"
 #include "time_zone_fixed.h"
@@ -628,6 +633,11 @@ class FileZoneInfoSource : public ZoneInfoSource {
       FILE* fp, std::size_t len = std::numeric_limits<std::size_t>::max())
       : fp_(fp, fclose), len_(len) {}
 
+  // Returns a file pointer and the size of the file in bytes. If the file
+  // cannot be opened, returns a null file pointer and a size of 0.
+  static std::pair<FILE*, std::size_t> OpenZoneInfoFile(
+      const std::string& path);
+
  private:
   std::unique_ptr<FILE, int(*)(FILE*)> fp_;
   std::size_t len_;
@@ -658,8 +668,18 @@ std::unique_ptr<ZoneInfoSource> FileZoneInfoSource::Open(
   path.append(name, pos, std::string::npos);
 
   // Open the zoneinfo file.
+  auto fp_and_len = FileZoneInfoSource::OpenZoneInfoFile(path);
+  if (fp_and_len.first == nullptr) {
+    return nullptr;
+  }
+  return std::unique_ptr<ZoneInfoSource>(
+      new FileZoneInfoSource(fp_and_len.first, fp_and_len.second));
+}
+
+std::pair<FILE*, std::size_t> FileZoneInfoSource::OpenZoneInfoFile(
+    const std::string& path) {
   FILE* fp = FOpen(path.c_str(), "rb");
-  if (fp == nullptr) return nullptr;
+  if (fp == nullptr) return std::make_pair(nullptr, 0);
   std::size_t length = 0;
   if (fseek(fp, 0, SEEK_END) == 0) {
     long offset = ftell(fp);
@@ -668,7 +688,7 @@ std::unique_ptr<ZoneInfoSource> FileZoneInfoSource::Open(
     }
     rewind(fp);
   }
-  return std::unique_ptr<ZoneInfoSource>(new FileZoneInfoSource(fp, length));
+  return std::make_pair(fp, length);
 }
 
 class AndroidZoneInfoSource : public FileZoneInfoSource {
@@ -725,6 +745,82 @@ std::unique_ptr<ZoneInfoSource> AndroidZoneInfoSource::Open(
   return nullptr;
 }
 
+#if defined(__Fuchsia__)
+// An info source for using cctz inside Fuchsia components. This attempts to
+// read zoneinfo files from one of several known paths in a component's
+// incoming namespace. [Config data][1] is preferred, but package-specific
+// resources are also supported.
+//
+// Fuchsia's implementation supports `FileZoneInfoSource::Version()`.
+//
+// [1]: https://fuchsia.dev/fuchsia-src/development/components/data#using_config_data_in_your_component
+class FuchsiaZoneInfoSource : public FileZoneInfoSource {
+ public:
+  static std::unique_ptr<ZoneInfoSource> Open(const std::string& name);
+  std::string Version() const override { return version_; }
+
+ private:
+  explicit FuchsiaZoneInfoSource(FILE* fp, std::size_t len, const char* vers)
+      : FileZoneInfoSource(fp, len), version_(vers) {}
+
+  std::string version_;
+};
+
+// Reads the contents of the file as ASCII. Returns an empty string on error.
+std::string ReadFileAsString(const std::string& path) {
+  std::ifstream input_stream(path);
+  if (!input_stream.good()) return "";
+  std::string contents((std::istreambuf_iterator<char>(input_stream)),
+                       std::istreambuf_iterator<char>());
+  return contents;
+}
+
+std::unique_ptr<ZoneInfoSource> FuchsiaZoneInfoSource::Open(
+    const std::string& name) {
+  // Locations where a Fuchsia component might find zoneinfo files, in
+  // descending order of preference.
+  const auto kTzdataPathPrefixes = {
+      "/config/data/tzdata/",
+      "/pkg/data/tzdata/",
+      "/data/tzdata/",
+  };
+  // Used for tests.
+  const auto kEmptyPathPrefixes = {""};
+  // Location under <tzdata> where tzif2 files are stored.
+  const auto kZoneinfoFormatPrefix = "zoneinfo/tzif2/";
+  // Fuchsia builds place the version string in <tzdata>/revision.txt.
+  const auto kVersionFileName = "revision.txt";
+
+  // Use of the "file:" prefix is intended for testing purposes only.
+  const std::size_t pos = (name.compare(0, 5, "file:") == 0) ? 5 : 0;
+  const bool is_test_path = (pos != name.size() && name[pos] == '/');
+  const auto path_prefixes =
+      is_test_path ? kEmptyPathPrefixes : kTzdataPathPrefixes;
+
+  for (const char* tzdata_dir : path_prefixes) {
+    // Map the time-zone name to a path name.
+    // Fuchsia builds place time zone files at <tzdata>/<format>/...
+    std::string path = tzdata_dir;
+    if (!is_test_path) {
+      path += kZoneinfoFormatPrefix;
+    }
+    path.append(name, pos, std::string::npos);
+
+    const auto fp_and_len = FileZoneInfoSource::OpenZoneInfoFile(path);
+    if (fp_and_len.first == nullptr) {
+      continue;
+    }
+
+    std::string version_path = tzdata_dir;
+    version_path += kVersionFileName;
+    std::string version_str = ReadFileAsString(version_path);
+
+    return std::unique_ptr<ZoneInfoSource>(new FuchsiaZoneInfoSource(
+        fp_and_len.first, fp_and_len.second, version_str.c_str()));
+  }
+  return nullptr;
+}
+#endif
 }  // namespace
 
 bool TimeZoneInfo::Load(const std::string& name) {
@@ -740,8 +836,12 @@ bool TimeZoneInfo::Load(const std::string& name) {
   // Find and use a ZoneInfoSource to load the named zone.
   auto zip = cctz_extension::zone_info_source_factory(
       name, [](const std::string& n) -> std::unique_ptr<ZoneInfoSource> {
+#if defined(__Fuchsia__)
+        if (auto z = FuchsiaZoneInfoSource::Open(n)) return z;
+#else
         if (auto z = FileZoneInfoSource::Open(n)) return z;
         if (auto z = AndroidZoneInfoSource::Open(n)) return z;
+#endif
         return nullptr;
       });
   return zip != nullptr && Load(zip.get());

--- a/src/time_zone_lookup.cc
+++ b/src/time_zone_lookup.cc
@@ -26,6 +26,14 @@
 #include <vector>
 #endif
 
+#if defined(__Fuchsia__)
+#include <fuchsia/intl/cpp/fidl.h>
+#include <lib/async-loop/cpp/loop.h>
+#include <lib/async-loop/default.h>
+#include <lib/sys/cpp/component_context.h>
+#include <zircon/types.h>
+#endif
+
 #include <cstdlib>
 #include <cstring>
 #include <string>
@@ -138,6 +146,31 @@ time_zone local_time_zone() {
     }
   }
   CFRelease(tz_default);
+#endif
+#if defined(__Fuchsia__)
+  // Note: Declared outside of unnamed scope to avoid early destruction.
+  std::string primary_tz;
+  {
+    const zx::duration kTimeout = zx::msec(500);
+
+    async::Loop loop(&kAsyncLoopConfigAttachToCurrentThread);
+    std::unique_ptr<sys::ComponentContext> context =
+        sys::ComponentContext::Create();
+    fuchsia::intl::PropertyProviderPtr intl_provider =
+        context->svc()->Connect<fuchsia::intl::PropertyProvider>();
+    intl_provider->GetProfile(
+        [&loop, &primary_tz](fuchsia::intl::Profile profile) {
+          if (!profile.time_zones().empty()) {
+            primary_tz = profile.time_zones()[0].id;
+          }
+          loop.Quit();
+        });
+    loop.Run(zx::deadline_after(kTimeout));
+
+    if (!primary_tz.empty()) {
+      zone = primary_tz.c_str();
+    }
+  }
 #endif
 
   // Allow ${TZ} to override to default zone.

--- a/src/time_zone_lookup_test.cc
+++ b/src/time_zone_lookup_test.cc
@@ -1022,7 +1022,11 @@ TEST(MakeTime, SysSecondsLimits) {
 #endif
     const year_t min_tm_year = year_t{std::numeric_limits<int>::min()} + 1900;
     tp = convert(civil_second(min_tm_year, 1, 1, 0, 0, 0), cut);
+#if defined(__Fuchsia__)
+    // Fuchsia's gmtime_r() fails on extreme negative tm_year values.
+#else
     EXPECT_EQ("-2147481748-01-01T00:00:00+00:00", format(RFC3339, tp, cut));
+#endif
 #endif
   }
 }

--- a/src/time_zone_lookup_test.cc
+++ b/src/time_zone_lookup_test.cc
@@ -1023,7 +1023,7 @@ TEST(MakeTime, SysSecondsLimits) {
     const year_t min_tm_year = year_t{std::numeric_limits<int>::min()} + 1900;
     tp = convert(civil_second(min_tm_year, 1, 1, 0, 0, 0), cut);
 #if defined(__Fuchsia__)
-    // Fuchsia's gmtime_r() fails on extreme negative tm_year values.
+    // Fuchsia's gmtime_r() fails on extreme negative values (fxbug.dev/78527).
 #else
     EXPECT_EQ("-2147481748-01-01T00:00:00+00:00", format(RFC3339, tp, cut));
 #endif


### PR DESCRIPTION
- Implement `FuchsiaZoneInfoSource` to read tzif2 files from their designated locations on Fuchsia systems.
- Implement calls to Fuchsia APIs in `local_time_zone()`.
- Disable a time conversion edge case that is unsupported on Fuchsia.

Bazel does not yet support Fuchsia configs, so these changes must be built and tested internally. See cl/374587662.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/cctz/189)
<!-- Reviewable:end -->
