### PR TITLE
Move raw FILE* values into an auto-closing unique_ptr ASAP.

### DIFF
--- a/src/time_zone_info.cc
+++ b/src/time_zone_info.cc
@@ -771,7 +771,7 @@ std::unique_ptr<ZoneInfoSource> FuchsiaZoneInfoSource::Open(
   const auto prefixes = name_absolute ? kEmptyPrefix : kTzdataPrefixes;
 
   // Fuchsia builds place zoneinfo files at "<prefix><format><name>".
-  for (const std::string prefix : prefixes) {
+  for (const std::string& prefix : prefixes) {
     std::string path = prefix;
     if (!prefix.empty()) path += "zoneinfo/tzif2/";  // format
     path.append(name, pos, std::string::npos);

--- a/src/time_zone_info.cc
+++ b/src/time_zone_info.cc
@@ -44,6 +44,7 @@
 #include <memory>
 #include <sstream>
 #include <string>
+#include <utility>
 
 #include "cctz/civil_time.h"
 #include "time_zone_fixed.h"
@@ -603,14 +604,17 @@ bool TimeZoneInfo::Load(ZoneInfoSource* zip) {
 
 namespace {
 
+using FilePtr = std::unique_ptr<FILE, int(*)(FILE*)>;
+
 // fopen(3) adaptor.
-inline FILE* FOpen(const char* path, const char* mode) {
+inline FilePtr FOpen(const char* path, const char* mode) {
 #if defined(_MSC_VER)
   FILE* fp;
   if (fopen_s(&fp, path, mode) != 0) fp = nullptr;
-  return fp;
+  return FilePtr(fp, fclose);
 #else
-  return fopen(path, mode);  // TODO: Enable the close-on-exec flag.
+  // TODO: Enable the close-on-exec flag.
+  return FilePtr(fopen(path, mode), fclose);
 #endif
 }
 
@@ -638,11 +642,11 @@ class FileZoneInfoSource : public ZoneInfoSource {
 
  protected:
   explicit FileZoneInfoSource(
-      FILE* fp, std::size_t len = std::numeric_limits<std::size_t>::max())
-      : fp_(fp, fclose), len_(len) {}
+      FilePtr fp, std::size_t len = std::numeric_limits<std::size_t>::max())
+      : fp_(std::move(fp)), len_(len) {}
 
  private:
-  std::unique_ptr<FILE, int(*)(FILE*)> fp_;
+  FilePtr fp_;
   std::size_t len_;
 };
 
@@ -671,17 +675,9 @@ std::unique_ptr<ZoneInfoSource> FileZoneInfoSource::Open(
   path.append(name, pos, std::string::npos);
 
   // Open the zoneinfo file.
-  FILE* fp = FOpen(path.c_str(), "rb");
-  if (fp == nullptr) return nullptr;
-  std::size_t length = 0;
-  if (fseek(fp, 0, SEEK_END) == 0) {
-    long offset = ftell(fp);
-    if (offset >= 0) {
-      length = static_cast<std::size_t>(offset);
-    }
-    rewind(fp);
-  }
-  return std::unique_ptr<ZoneInfoSource>(new FileZoneInfoSource(fp, length));
+  auto fp = FOpen(path.c_str(), "rb");
+  if (fp.get() == nullptr) return nullptr;
+  return std::unique_ptr<ZoneInfoSource>(new FileZoneInfoSource(std::move(fp)));
 }
 
 class AndroidZoneInfoSource : public FileZoneInfoSource {
@@ -690,8 +686,9 @@ class AndroidZoneInfoSource : public FileZoneInfoSource {
   std::string Version() const override { return version_; }
 
  private:
-  explicit AndroidZoneInfoSource(FILE* fp, std::size_t len, const char* vers)
-      : FileZoneInfoSource(fp, len), version_(vers) {}
+  explicit AndroidZoneInfoSource(FilePtr fp, std::size_t len,
+                                 std::string version)
+      : FileZoneInfoSource(std::move(fp), len), version_(std::move(version)) {}
   std::string version_;
 };
 
@@ -703,7 +700,7 @@ std::unique_ptr<ZoneInfoSource> AndroidZoneInfoSource::Open(
   // See Android's libc/tzcode/bionic.cpp for additional information.
   for (const char* tzdata : {"/data/misc/zoneinfo/current/tzdata",
                              "/system/usr/share/zoneinfo/tzdata"}) {
-    std::unique_ptr<FILE, int (*)(FILE*)> fp(FOpen(tzdata, "rb"), fclose);
+    auto fp = FOpen(tzdata, "rb");
     if (fp.get() == nullptr) continue;
 
     char hbuf[24];  // covers header.zonetab_offset too
@@ -730,7 +727,7 @@ std::unique_ptr<ZoneInfoSource> AndroidZoneInfoSource::Open(
       if (strcmp(name.c_str() + pos, ebuf) == 0) {
         if (fseek(fp.get(), static_cast<long>(start), SEEK_SET) != 0) break;
         return std::unique_ptr<ZoneInfoSource>(new AndroidZoneInfoSource(
-            fp.release(), static_cast<std::size_t>(length), vers));
+            std::move(fp), static_cast<std::size_t>(length), vers));
       }
     }
   }
@@ -752,70 +749,54 @@ class FuchsiaZoneInfoSource : public FileZoneInfoSource {
   std::string Version() const override { return version_; }
 
  private:
-  explicit FuchsiaZoneInfoSource(FILE* fp, const char* vers)
-      : FileZoneInfoSource(fp), version_(vers) {}
-
+  explicit FuchsiaZoneInfoSource(FilePtr fp, std::string version)
+      : FileZoneInfoSource(std::move(fp)), version_(std::move(version)) {}
   std::string version_;
 };
 
-// Reads the first line of the file into a string. Returns an empty string on
-// error.
-std::string ReadFirstLine(const std::string& path) {
-  std::string line;
-  std::ifstream input_stream(path);
-  if (input_stream.good()) {
-    std::getline(input_stream, line);
-  }
-  return line;
-}
-
 std::unique_ptr<ZoneInfoSource> FuchsiaZoneInfoSource::Open(
     const std::string& name) {
-  // Locations where a Fuchsia component might find zoneinfo files, in
-  // descending order of preference.
-  const auto kTzdataPathPrefixes = {
+  // Use of the "file:" prefix is intended for testing purposes only.
+  const std::size_t pos = (name.compare(0, 5, "file:") == 0) ? 5 : 0;
+
+  // Prefixes where a Fuchsia component might find zoneinfo files,
+  // in descending order of preference.
+  const auto kTzdataPrefixes = {
       "/config/data/tzdata/",
       "/pkg/data/tzdata/",
       "/data/tzdata/",
   };
-  // Used for tests.
-  const auto kEmptyPathPrefixes = {""};
-  // Location under <tzdata> where tzif2 files are stored.
-  const auto kZoneinfoFormatPrefix = "zoneinfo/tzif2/";
-  // Fuchsia builds place the version string in <tzdata>/revision.txt.
-  const auto kVersionFileName = "revision.txt";
+  const auto kEmptyPrefix = {""};
+  const bool name_absolute = (pos != name.size() && name[pos] == '/');
+  const auto prefixes = name_absolute ? kEmptyPrefix : kTzdataPrefixes;
 
-  // Use of the "file:" prefix is intended for testing purposes only.
-  const std::size_t pos = (name.compare(0, 5, "file:") == 0) ? 5 : 0;
-  const bool is_absolute_path = (pos != name.size() && name[pos] == '/');
-  const auto path_prefixes =
-      is_absolute_path ? kEmptyPathPrefixes : kTzdataPathPrefixes;
-
-  for (const char* tzdata_dir : path_prefixes) {
-    // Map the time-zone name to a path name.
-    // Fuchsia builds place time zone files at <tzdata>/<format>/...
-    std::string path = tzdata_dir;
-    if (!is_absolute_path) {
-      path += kZoneinfoFormatPrefix;
-    }
+  // Fuchsia builds place zoneinfo files at "<prefix><format><name>".
+  for (const std::string prefix : prefixes) {
+    std::string path = prefix;
+    if (!prefix.empty()) path += "zoneinfo/tzif2/";  // format
     path.append(name, pos, std::string::npos);
 
-    FILE* fp = FOpen(path.c_str(), "rb");
-    if (fp == nullptr) {
-      continue;
+    auto fp = FOpen(path.c_str(), "rb");
+    if (fp.get() == nullptr) continue;
+
+    std::string version;
+    if (!prefix.empty()) {
+      // Fuchsia builds place the version in "<prefix>revision.txt".
+      std::ifstream version_stream(prefix + "revision.txt");
+      if (version_stream.is_open()) {
+        // revision.txt should contain no newlines, but to be
+        // defensive we read just the first line.
+        std::getline(version_stream, version);
+      }
     }
 
-    std::string version_path = tzdata_dir;
-    version_path += kVersionFileName;
-    // revision.txt should contain no newlines, but to be defensive we read just
-    // the first line.
-    std::string version_str = ReadFirstLine(version_path);
-
     return std::unique_ptr<ZoneInfoSource>(
-        new FuchsiaZoneInfoSource(fp, version_str.c_str()));
+        new FuchsiaZoneInfoSource(std::move(fp), std::move(version)));
   }
+
   return nullptr;
 }
+
 }  // namespace
 
 bool TimeZoneInfo::Load(const std::string& name) {


### PR DESCRIPTION
All `FileZoneInfoSource`-derived classes now accept transfer of
of that `unique_ptr`.

Also remove the `FileZoneInfoSource::Open()` code to determine
the length of the zoneinfo file.  We do not need the length when
we read to EOF.

Finally, refactor the new `FuchsiaZoneInfoSource` code a little.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/cctz/190)
<!-- Reviewable:end -->
