### PR TITLE
Fixes -Wrange-loop-construct warning in GCC 11

### DIFF
--- a/src/time_zone_info.cc
+++ b/src/time_zone_info.cc
@@ -771,7 +771,7 @@ std::unique_ptr<ZoneInfoSource> FuchsiaZoneInfoSource::Open(
   const auto prefixes = name_absolute ? kEmptyPrefix : kTzdataPrefixes;
 
   // Fuchsia builds place zoneinfo files at "<prefix><format><name>".
-  for (const std::string& prefix : prefixes) {
+  for (const std::string prefix : prefixes) {
     std::string path = prefix;
     if (!prefix.empty()) path += "zoneinfo/tzif2/";  // format
     path.append(name, pos, std::string::npos);


### PR DESCRIPTION
This is similar to #188, but fixes the issue introduced in #190.

I'm sending a separate change to upgrade to GCC 11 to prevent these
from sneaking in.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/cctz/191)
<!-- Reviewable:end -->
