### PR TITLE
CMake: fix cross-build to iOS when tools are enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,7 +100,9 @@ target_include_directories(cctz PUBLIC
 set_target_properties(cctz PROPERTIES
   PUBLIC_HEADER "${CCTZ_HDRS}"
   )
-target_link_libraries(cctz PUBLIC $<$<PLATFORM_ID:Darwin>:${CoreFoundation}>)  
+if(APPLE)
+  target_link_libraries(cctz PUBLIC ${CoreFoundation})
+endif()
 add_library(cctz::cctz ALIAS cctz)
 
 if (BUILD_TOOLS)
@@ -169,7 +171,7 @@ install(TARGETS cctz
 if (BUILD_TOOLS)
   install(TARGETS time_tool
     EXPORT ${PROJECT_NAME}-targets
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    DESTINATION ${CMAKE_INSTALL_BINDIR}
     )
 endif()
 set(CMAKE_INSTALL_CONFIGDIR ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})


### PR DESCRIPTION
1. When we cross-build to iOS, by default PLATFORM_ID is not set, while APPLE variable is. Without this modification, CoreFoundation is not linked under iOS/tvOS/watchOS, leading to undefined references (at link time of dependent tools).

2. Due to https://cmake.org/cmake/help/latest/policy/CMP0006.html, RUNTIME DESTINATION for executables is not sufficient for iOS/tvOS/watchOS, they need BUNDLE DESTINATION.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/cctz/193)
<!-- Reviewable:end -->
