### PR TITLE
Remove bazelbuild/rules_cc dependency

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -12,8 +12,6 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
-
 licenses(["notice"])
 
 config_setting(


### PR DESCRIPTION
The Bazel team recommends using native rules nowadays: https://github.com/bazelbuild/rules_cc/issues/91#issuecomment-756673529
Abseil stopped depending on `rules_cc` in https://github.com/abseil/abseil-cpp/pull/1038/commits/b2387f0b2326efc3fac804426e335a91085839d1.