### PR TITLE
Small microptimization to year_index.

### DIFF
--- a/include/cctz/civil_time_detail.h
+++ b/include/cctz/civil_time_detail.h
@@ -79,14 +79,13 @@ CONSTEXPR_F bool is_leap_year(year_t y) noexcept {
   return y % 4 == 0 && (y % 100 != 0 || y % 400 == 0);
 }
 CONSTEXPR_F int year_index(year_t y, month_t m) noexcept {
-  return (static_cast<int>((y + (m > 2)) % 400) + 400) % 400;
+  const int yi = static_cast<int>((y + (m > 2)) % 400);
+  return yi < 0 ? yi + 400 : yi;
 }
-CONSTEXPR_F int days_per_century(year_t y, month_t m) noexcept {
-  const int yi = year_index(y, m);
+CONSTEXPR_F int days_per_century(int yi) noexcept {
   return 36524 + (yi == 0 || yi > 300);
 }
-CONSTEXPR_F int days_per_4years(year_t y, month_t m) noexcept {
-  const int yi = year_index(y, m);
+CONSTEXPR_F int days_per_4years(int yi) noexcept {
   return 1460 + (yi == 0 || yi > 300 || (yi - 1) % 100 < 96);
 }
 CONSTEXPR_F int days_per_year(year_t y, month_t m) noexcept {
@@ -128,17 +127,22 @@ CONSTEXPR_F fields n_day(year_t y, month_t m, diff_t d, diff_t cd,
     }
   }
   if (d > 365) {
+    int yi = year_index(ey, m);  // Index into Gregorian 400 year cycle.
     for (;;) {
-      int n = days_per_century(ey, m);
+      int n = days_per_century(yi);
       if (d <= n) break;
       d -= n;
       ey += 100;
+      yi += 100;
+      if (yi >= 400) yi -= 400;
     }
     for (;;) {
-      int n = days_per_4years(ey, m);
+      int n = days_per_4years(yi);
       if (d <= n) break;
       d -= n;
       ey += 4;
+      yi += 4;
+      if (yi >= 400) yi -= 400;
     }
     for (;;) {
       int n = days_per_year(ey, m);


### PR DESCRIPTION
    There are two optimizations. The first is to cache the year index while
    stepping through 100 year and 4 year intervals in n_day.
    
    The second is an optimization to the year index calculation itself.
    The year_index function had been forcing the modulus result to be
    non-negative by adding 400 and taking the modulus again. Even with the
    multiply&shift technique that compilers use for integer division with
    known divisor, this isn't very cheap. Most of the time it should be
    faster to do a conditional-move or branch on the modulus results, though
    it is possible there are processors where this isn't faster.

Some microbenchmark results:

```
name                                                         old time/op             new time/op             delta
BM_Difference_Days                                           14.5ns ± 3%             14.6ns ± 3%     ~             (p=0.387 n=9+9)
BM_Step_Days                                                 10.5ns ± 1%             10.5ns ± 2%     ~             (p=0.645 n=8+8)
BM_GetWeekday                                                1.49ns ± 3%             1.50ns ± 2%     ~             (p=0.520 n=8+8)
BM_NextWeekday                                               13.6ns ± 6%             13.3ns ± 3%     ~             (p=0.050 n=9+9)
BM_PrevWeekday                                               12.6ns ± 3%             12.3ns ± 4%   -2.36%          (p=0.019 n=9+9)
BM_Zone_LoadUTCTimeZoneFirst                                 13.2ns ± 2%             13.0ns ± 4%     ~             (p=0.200 n=8+9)
BM_Zone_LoadUTCTimeZoneLast                                  14.0ns ±13%             13.1ns ± 4%     ~            (p=0.252 n=10+9)
BM_Zone_LoadTimeZoneFirst                                     354µs ± 4%              294µs ± 3%  -16.99%         (p=0.000 n=10+8)
BM_Zone_LoadTimeZoneCached                                   40.2ns ± 7%             39.4ns ± 9%     ~             (p=0.387 n=9+9)
BM_Zone_LoadLocalTimeZoneCached                               136ns ± 6%              136ns ±14%     ~            (p=0.497 n=10+9)
BM_Zone_LoadAllTimeZonesFirst                                 183µs ±29%              117µs ±16%  -36.09%         (p=0.000 n=10+8)
BM_Zone_LoadAllTimeZonesCached                               67.7ns ± 6%             66.2ns ± 4%     ~             (p=0.094 n=9+9)
BM_Zone_TimeZoneEqualityImplicit                             5.82ns ± 4%             5.78ns ± 2%     ~             (p=0.288 n=9+8)
BM_Zone_TimeZoneEqualityExplicit                             2.46ns ± 4%             2.46ns ± 3%     ~            (p=1.000 n=10+9)
BM_Zone_UTCTimeZone                                          2.47ns ± 3%             2.48ns ± 2%     ~             (p=0.666 n=9+9)
BM_Time_ToCivil_CCTZ                                         43.9ns ± 5%             43.5ns ± 3%     ~            (p=0.447 n=10+9)
BM_Time_ToCivil_Libc                                         67.3ns ± 3%             67.4ns ± 1%     ~             (p=0.815 n=9+8)
BM_Time_ToCivilUTC_CCTZ                                       117ns ± 4%               83ns ± 3%  -29.14%         (p=0.000 n=10+9)
BM_Time_ToCivilUTC_Libc                                      40.9ns ± 2%             40.7ns ± 3%     ~             (p=0.888 n=8+9)
BM_Time_FromCivil_CCTZ                                       36.4ns ± 1%             36.2ns ± 2%     ~             (p=1.000 n=8+9)
BM_Time_FromCivil_Libc                                       1.00µs ± 3%             1.00µs ± 4%     ~             (p=0.489 n=9+9)
BM_Time_FromCivilUTC_CCTZ                                    27.2ns ± 0%             26.9ns ± 3%   -1.10%          (p=0.026 n=7+8)
BM_Time_FromCivilDay0_CCTZ                                   61.2ns ± 1%             60.5ns ± 5%     ~             (p=0.370 n=8+9)
BM_Time_FromCivilDay0_Libc                                   1.07µs ± 3%             1.07µs ± 4%     ~            (p=0.780 n=10+9)
BM_Format_FormatTime/0           [%a, %d %b %Y %H:%M:%S %z]   393ns ±14%              367ns ± 3%     ~            (p=0.079 n=10+9)
BM_Format_FormatTime/1           [%d %b %Y %H:%M:%S %z    ]   312ns ± 3%              314ns ± 4%     ~            (p=0.515 n=10+8)
BM_Format_FormatTime/2           [%Y-%m-%d%ET%H:%M:%E*S%Ez]   307ns ± 3%              306ns ± 3%     ~             (p=0.730 n=9+9)
BM_Format_FormatTime/3           [%Y-%m-%d%ET%H:%M:%S%Ez  ]   279ns ± 1%              277ns ± 4%     ~             (p=0.536 n=7+9)
BM_Format_FormatTime/4           [%Y-%m-%d%ET%H:%M:%S     ]   236ns ± 4%              238ns ± 3%     ~             (p=0.489 n=9+9)
BM_Format_FormatTime/5           [%Y-%m-%d                ]   126ns ± 3%              126ns ± 3%     ~             (p=0.963 n=9+8)
BM_Format_ParseTime/0            [%a, %d %b %Y %H:%M:%S %z]  1.41µs ± 3%             1.40µs ± 4%     ~             (p=0.546 n=9+9)
BM_Format_ParseTime/1            [%d %b %Y %H:%M:%S %z    ]  1.15µs ± 9%             1.17µs ±16%     ~            (p=0.720 n=9+10)
BM_Format_ParseTime/2            [%Y-%m-%d%ET%H:%M:%E*S%Ez]   305ns ± 4%              302ns ± 3%     ~            (p=0.447 n=10+9)
BM_Format_ParseTime/3            [%Y-%m-%d%ET%H:%M:%S%Ez  ]   272ns ± 1%              271ns ± 2%     ~             (p=0.743 n=9+8)
BM_Format_ParseTime/4            [%Y-%m-%d%ET%H:%M:%S     ]   165ns ± 2%              173ns ±16%     ~            (p=0.780 n=9+10)
BM_Format_ParseTime/5            [%Y-%m-%d                ]   113ns ± 4%              114ns ± 4%     ~             (p=0.606 n=9+8)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/cctz/209)
<!-- Reviewable:end -->
