### PR TITLE
[Fuchsia] Reduce number of threads for LoadZonesConcurrently.

### DIFF
--- a/src/time_zone_lookup_test.cc
+++ b/src/time_zone_lookup_test.cc
@@ -685,7 +685,14 @@ TEST(TimeZones, LoadZonesConcurrently) {
     }
   };
 
+#if defined(__Fuchsia__)
+  // On Fuchsia, the test will often timeout with the thread count set to 128.
+  // This lower thread count ensures the test passes consistently.
+  const std::size_t n_threads = 64;
+#else
   const std::size_t n_threads = 128;
+#endif
+
   std::vector<std::thread> threads;
   std::vector<std::set<std::string>> thread_failures(n_threads);
   for (std::size_t i = 0; i != n_threads; ++i) {

--- a/src/time_zone_lookup_test.cc
+++ b/src/time_zone_lookup_test.cc
@@ -685,14 +685,7 @@ TEST(TimeZones, LoadZonesConcurrently) {
     }
   };
 
-#if defined(__Fuchsia__)
-  // On Fuchsia, the test will often timeout with the thread count set to 128.
-  // This lower thread count ensures the test passes consistently.
-  const std::size_t n_threads = 64;
-#else
-  const std::size_t n_threads = 128;
-#endif
-
+  const std::size_t n_threads = std::thread::hardware_concurrency();
   std::vector<std::thread> threads;
   std::vector<std::set<std::string>> thread_failures(n_threads);
   for (std::size_t i = 0; i != n_threads; ++i) {


### PR DESCRIPTION
This reduces the thread count from 128 -> 64 when running on Fuchsia.
With the higher thread count, the test was flaky and would often time
out.

To test, I ran this 100 times to verify that it passes each time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/cctz/213)
<!-- Reviewable:end -->
