### PR TITLE
Update the script for generating testdata/zoneinfo.

### DIFF
--- a/testdata/README.zoneinfo
+++ b/testdata/README.zoneinfo
@@ -13,7 +13,12 @@ New versions can be generated using the following shell script.
   trap "rm -fr ${DESTDIR}" 0 2 15
   (
     cd ${DESTDIR}
-    git clone https://github.com/eggert/tz.git
+    if [ -n "${USE_GLOBAL_TZ}" ]
+    then
+      git clone -b global-tz https://github.com/JodaOrg/global-tz.git tz
+    else
+      git clone https://github.com/eggert/tz.git
+    fi
     make --directory=tz \
         install DESTDIR=${DESTDIR} \
                 DATAFORM=vanguard \


### PR DESCRIPTION
Provide a switch to use github.com/JodaOrg/global-tz (which reinstates
rules removed from recent versions of the IANA database) as the tzdata
source.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/cctz/219)
<!-- Reviewable:end -->
