### PR TITLE
Limit testing of extended format/parse specifiers to GLIBC

### DIFF
--- a/src/time_zone_format_test.cc
+++ b/src/time_zone_format_test.cc
@@ -19,6 +19,9 @@
 #include <iomanip>
 #include <sstream>
 #include <string>
+#if defined(__linux__)
+#include <features.h>
+#endif
 
 #include "cctz/civil_time.h"
 #include "gmock/gmock.h"
@@ -177,8 +180,10 @@ TEST(Format, PosixConversions) {
   TestFormatSpecifier(tp, tz, "%F", "1970-01-01");
   TestFormatSpecifier(tp, tz, "%g", "70");
   TestFormatSpecifier(tp, tz, "%G", "1970");
+#if defined(__GLIBC__)
   TestFormatSpecifier(tp, tz, "%k", " 0");
   TestFormatSpecifier(tp, tz, "%l", "12");
+#endif
   TestFormatSpecifier(tp, tz, "%n", "\n");
   TestFormatSpecifier(tp, tz, "%R", "00:00");
   TestFormatSpecifier(tp, tz, "%t", "\t");
@@ -210,7 +215,9 @@ TEST(Format, LocaleSpecific) {
 #if defined(__linux__)
   // SU/C99/TZ extensions
   TestFormatSpecifier(tp, tz, "%h", "Jan");  // Same as %b
+#if defined(__GLIBC__)
   TestFormatSpecifier(tp, tz, "%P", "am");
+#endif
   TestFormatSpecifier(tp, tz, "%r", "12:00:00 AM");
 
   // Modified conversion specifiers %E_
@@ -1039,9 +1046,11 @@ TEST(Parse, LocaleSpecific) {
   EXPECT_TRUE(parse("%h", "Feb", tz, &tp));
   EXPECT_EQ(2, convert(tp, tz).month());  // Equivalent to %b
 
+#if defined(__GLIBC__)
   tp = reset;
   EXPECT_TRUE(parse("%l %p", "5 PM", tz, &tp));
   EXPECT_EQ(17, convert(tp, tz).hour());
+#endif
 
   tp = reset;
   EXPECT_TRUE(parse("%r", "03:44:55 PM", tz, &tp));
@@ -1049,6 +1058,7 @@ TEST(Parse, LocaleSpecific) {
   EXPECT_EQ(44, convert(tp, tz).minute());
   EXPECT_EQ(55, convert(tp, tz).second());
 
+#if defined(__GLIBC__)
   tp = reset;
   EXPECT_TRUE(parse("%Ec", "Tue Nov 19 05:06:07 2013", tz, &tp));
   EXPECT_EQ(convert(civil_second(2013, 11, 19, 5, 6, 7), tz), tp);
@@ -1119,6 +1129,7 @@ TEST(Parse, LocaleSpecific) {
   tp = reset;
   EXPECT_TRUE(parse("%Oy", "04", tz, &tp));
   EXPECT_EQ(2004, convert(tp, tz).year());
+#endif
 #endif
 }
 


### PR DESCRIPTION
Restrict testing of some extended format/parse specifiers (e.g.,
%k, %l, and %P) to platforms that define `__GLIBC__`.  This means
the tests can run with alternative Linux C run-time libraries,
like https://musl.libc.org/, that do not support those extensions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/cctz/220)
<!-- Reviewable:end -->
