### PR TITLE
Limit MakeTime.LocalTimeLibC test to GLIBC

### DIFF
--- a/src/time_zone_lookup_test.cc
+++ b/src/time_zone_lookup_test.cc
@@ -22,6 +22,9 @@
 #include <string>
 #include <thread>
 #include <vector>
+#if defined(__linux__)
+#include <features.h>
+#endif
 
 #include "cctz/civil_time.h"
 #include "gtest/gtest.h"
@@ -1039,7 +1042,7 @@ TEST(MakeTime, LocalTimeLibC) {
   //  1) we know how to change the time zone used by localtime()/mktime(),
   //  2) cctz and localtime()/mktime() will use similar-enough tzdata, and
   //  3) we have some idea about how mktime() behaves during transitions.
-#if defined(__linux__) && !defined(__ANDROID__)
+#if defined(__linux__) && defined(__GLIBC__) && !defined(__ANDROID__)
   const char* const ep = getenv("TZ");
   std::string tz_name = (ep != nullptr) ? ep : "";
   for (const char* const* np = kTimeZoneNames; *np != nullptr; ++np) {


### PR DESCRIPTION
Further restrict the environments where we know what to expect from
`mktime()`; in particular to `__GLIBC__`.  This means the test will
also be skipped when run with alternative Linux C run-time libraries,
like https://musl.libc.org/.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/cctz/221)
<!-- Reviewable:end -->
