### PR TITLE
Make cctz civil(fields) constructor public

### DIFF
--- a/include/cctz/civil_time_detail.h
+++ b/include/cctz/civil_time_detail.h
@@ -424,14 +424,17 @@ class civil_time {
     return difference(T{}, lhs.f_, rhs.f_);
   }
 
+  // The designated constructor that all others eventually call.
+  // Does no normalization checks, use with extreme care in performance
+  // sensitive situations.
+  explicit CONSTEXPR_M civil_time(fields f) noexcept : f_(align(T{}, f)) {}
+
  private:
   // All instantiations of this template are allowed to call the following
   // private constructor and access the private fields member.
   template <typename U>
   friend class civil_time;
 
-  // The designated constructor that all others eventually call.
-  explicit CONSTEXPR_M civil_time(fields f) noexcept : f_(align(T{}, f)) {}
 
   fields f_;
 };


### PR DESCRIPTION
This allows use of a faster constructor when it is certain that provided year/month/day/hour/minute/second are within acceptable ranges.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/cctz/225)
<!-- Reviewable:end -->
