### PR TITLE
Fix call placement of recently-introduced AllYearDST()

### DIFF
--- a/src/time_zone_info.cc
+++ b/src/time_zone_info.cc
@@ -345,7 +345,6 @@ bool TimeZoneInfo::ExtendTransitions() {
 
   PosixTimeZone posix;
   if (!ParsePosixSpec(future_spec_, &posix)) return false;
-  if (AllYearDST(posix)) return true;  // last transition still prevails
 
   // Find transition type for the future std specification.
   std::uint_least8_t std_ti;
@@ -362,6 +361,12 @@ bool TimeZoneInfo::ExtendTransitions() {
   std::uint_least8_t dst_ti;
   if (!GetTransitionType(posix.dst_offset, true, posix.dst_abbr, &dst_ti))
     return false;
+
+  if (AllYearDST(posix)) {  // dst only
+    // The future specification should match the last transition, and
+    // that means that handling the future will fall out naturally.
+    return EquivTransitions(transitions_.back().type_index, dst_ti);
+  }
 
   // Extend the transitions for an additional 400 years using the
   // future specification. Years beyond those can be handled by


### PR DESCRIPTION
Do not look at DST start and end date/time until we know they
have been initialized.  Also add a check that the prevailing
transition matches the POSIX rule for year-round DST.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/cctz/229)
<!-- Reviewable:end -->
