### PR TITLE
cleanup: zic.c no longer tries to "WORK_AROUND_QTBUG_53071"

### DIFF
--- a/src/time_zone_info.cc
+++ b/src/time_zone_info.cc
@@ -547,8 +547,8 @@ bool TimeZoneInfo::Load(ZoneInfoSource* zip) {
 
   // Trim redundant transitions. zic may have added these to work around
   // differences between the glibc and reference implementations (see
-  // zic.c:dontmerge) and the Qt library (see zic.c:WORK_AROUND_QTBUG_53071).
-  // For us, they just get in the way when we do future_spec_ extension.
+  // zic.c:dontmerge) or to avoid bugs in old readers. For us, they just
+  // get in the way when we do future_spec_ extension.
   while (hdr.timecnt > 1) {
     if (!EquivTransitions(transitions_[hdr.timecnt - 1].type_index,
                           transitions_[hdr.timecnt - 2].type_index)) {


### PR DESCRIPTION
See https://github.com/eggert/tz/commit/bbbb46c.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/cctz/234)
<!-- Reviewable:end -->
