### PR TITLE
Fix skipping unused portions in TimeZoneInfo::Load() for version 1 zonefiles

### DIFF
--- a/src/time_zone_info.cc
+++ b/src/time_zone_info.cc
@@ -514,9 +514,9 @@ bool TimeZoneInfo::Load(ZoneInfoSource* zip) {
   // encoded zoneinfo. The ttisstd/ttisgmt indicators only apply when
   // interpreting a POSIX spec that does not include start/end rules, and
   // that isn't the case here (see "zic -p").
-  bp += (8 + 4) * hdr.leapcnt;  // leap-time + TAI-UTC
-  bp += 1 * hdr.ttisstdcnt;     // UTC/local indicators
-  bp += 1 * hdr.ttisutcnt;      // standard/wall indicators
+  bp += (time_len + 4) * hdr.leapcnt;  // leap-time + TAI-UTC
+  bp += 1 * hdr.ttisstdcnt;            // UTC/local indicators
+  bp += 1 * hdr.ttisutcnt;             // standard/wall indicators
   assert(bp == tbuf.data() + tbuf.size());
 
   future_spec_.clear();


### PR DESCRIPTION
In theory, leap-second record of version 1 zonefiles is 4 + 4 bytes per record.
https://www.rfc-editor.org/rfc/rfc8536.html#section-3.2

In practice, this commit won't make any difference because we return early at line 437 if hdr.leapcnt != 0.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/cctz/236)
<!-- Reviewable:end -->
