### PR TITLE
build: fix cross-platform android builds on OS X

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -14,13 +14,6 @@
 
 licenses(["notice"])
 
-config_setting(
-    name = "ios",
-    constraint_values = [
-        "@platforms//os:ios",
-    ],
-)
-
 ### libraries
 
 cc_library(
@@ -59,12 +52,9 @@ cc_library(
         "include/cctz/zone_info_source.h",
     ],
     includes = ["include"],
-    linkopts = select({
-        "//:ios": [
-            "-framework Foundation",
-        ],
-        "//conditions:default": [],
-    }),
+    # Note that OS X and iOS both have an implicit dependency on Foundation but
+    # it is no longer explicitly added as a linkopt as bazel adds it
+    # automatically. See https://github.com/abseil/abseil-cpp/issues/326 for details.
     visibility = ["//visibility:public"],
     deps = [":civil_time"],
 )

--- a/BUILD
+++ b/BUILD
@@ -52,9 +52,10 @@ cc_library(
         "include/cctz/zone_info_source.h",
     ],
     includes = ["include"],
-    # Note that OS X and iOS both have an implicit dependency on Foundation but
-    # it is no longer explicitly added as a linkopt as bazel adds it
-    # automatically. See https://github.com/abseil/abseil-cpp/issues/326 for details.
+    # Note that OS X and iOS both have a dependency on Foundation but it is no
+    # longer explicitly added as a linkopt as that causes problems cross-compiling android
+    # builds on OSX, and bazel will add it automatically.
+    # See https://github.com/abseil/abseil-cpp/issues/326 for details.
     visibility = ["//visibility:public"],
     deps = [":civil_time"],
 )

--- a/BUILD
+++ b/BUILD
@@ -67,9 +67,6 @@ cc_library(
     ],
     includes = ["include"],
     linkopts = select({
-        "//:osx": [
-            "-framework Foundation",
-        ],
         "//:ios": [
             "-framework Foundation",
         ],

--- a/BUILD
+++ b/BUILD
@@ -15,13 +15,6 @@
 licenses(["notice"])
 
 config_setting(
-    name = "osx",
-    constraint_values = [
-        "@platforms//os:osx",
-    ],
-)
-
-config_setting(
     name = "ios",
     constraint_values = [
         "@platforms//os:ios",

--- a/BUILD
+++ b/BUILD
@@ -52,10 +52,9 @@ cc_library(
         "include/cctz/zone_info_source.h",
     ],
     includes = ["include"],
-    # Note that OS X and iOS both have a dependency on CoreFoundation but it is
-    # no longer explicitly added as a linkopt as that causes problems
-    # cross-compiling android builds on OSX, and bazel will add it
-    # automatically.
+    # OS X and iOS no longer use `linkopts = ["-framework CoreFoundation"]`
+    # as (1) bazel adds it automatically, and (2) it caused problems when
+    # cross-compiling for Android.
     # See https://github.com/abseil/abseil-cpp/issues/326 for details.
     visibility = ["//visibility:public"],
     deps = [":civil_time"],

--- a/BUILD
+++ b/BUILD
@@ -52,9 +52,10 @@ cc_library(
         "include/cctz/zone_info_source.h",
     ],
     includes = ["include"],
-    # Note that OS X and iOS both have a dependency on Foundation but it is no
-    # longer explicitly added as a linkopt as that causes problems cross-compiling android
-    # builds on OSX, and bazel will add it automatically.
+    # Note that OS X and iOS both have a dependency on CoreFoundation but it is
+    # no longer explicitly added as a linkopt as that causes problems
+    # cross-compiling android builds on OSX, and bazel will add it
+    # automatically.
     # See https://github.com/abseil/abseil-cpp/issues/326 for details.
     visibility = ["//visibility:public"],
     deps = [":civil_time"],


### PR DESCRIPTION
Fixing https://github.com/abseil/abseil-cpp/issues/326 by removing a non-working Foundation linkopt for OS X and iOS.
Foundation should now be implicitly added by modern versions of bazel so this will hopefully not be problematic for builds previously affected by https://github.com/abseil/abseil-cpp/issues/291

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/cctz/237)
<!-- Reviewable:end -->

co-authored-by: [devbww](https://github.com/devbww)
