### PR TITLE
local_time_zone: Add Windows support with WinRT

### DIFF
--- a/src/time_zone_lookup.cc
+++ b/src/time_zone_lookup.cc
@@ -43,7 +43,6 @@
 #include <wchar.h>
 #include <windows.globalization.h>
 #include <windows.h>
-#include <vector>
 #endif
 #endif
 


### PR DESCRIPTION
The Windows API histrocally didn't use the IANA time zone names, however, Windows 10 introduced the new WinRT Calendar class that returns the IANA identifiers.

This PR uses the new API and gets the local time zone on Windows 10 and later. To maintain binary compatibility with Windows 7 and earlier (down to Windows XP), the DLL and function pointers are dynamically loaded. It still requires the application developer to provide zoneinfo (e.g. setting the TZDIR environment variable).

Issue: #53

Test run:

```
PS C:\src\cctz> [System.Environment]::OSVersion

Platform ServicePack Version      VersionString
-------- ----------- -------      -------------
 Win32NT             10.0.19045.0 Microsoft Windows NT 10.0.19045.0

PS C:\src\cctz> Set-Timezone "Tokyo Standard Time"
PS C:\src\cctz> Get-Timezone

Id                         : Tokyo Standard Time
HasIanaId                  : False
DisplayName                : (UTC+09:00) Osaka, Sapporo, Tokyo
StandardName               : Tokyo Standard Time
DaylightName               : Tokyo Daylight Time
BaseUtcOffset              : 09:00:00
SupportsDaylightSavingTime : False


PS C:\src\cctz> $ENV:TZDIR="C:\src\cctz\testdata\zoneinfo"
PS C:\src\cctz> bazel run :time_tool
INFO: Analyzed target //:time_tool (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //:time_tool up-to-date:
  bazel-bin/time_tool.exe
INFO: Elapsed time: 0.438s, Critical Path: 0.01s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-bin/time_tool.exe
tz: Asia/Tokyo [ver=<unknown> #trans=10 #types=3 spec='JST-9']
kind: UNIQUE
when {
  time_t: 1684532590
     UTC: 2023-05-19 21:43:10 +00:00:00 (UTC)  [wd=Fri yd=139 dst=F off=+0]
   local: 2023-05-20 06:43:10 +09:00:00 (JST)  [wd=Sat yd=140 dst=F off=+32400]
   in-tz: 2023-05-20 06:43:10 +09:00:00 (JST)  [wd=Sat yd=140 dst=F off=+32400]
}
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/cctz/242)
<!-- Reviewable:end -->
