### PR TITLE
Fully qualify cctz::format in tests

### DIFF
--- a/src/time_zone_format_test.cc
+++ b/src/time_zone_format_test.cc
@@ -60,10 +60,10 @@ const char RFC1123_no_wday[] =  "%d %b %Y %H:%M:%S %z";
 template <typename D>
 void TestFormatSpecifier(time_point<D> tp, time_zone tz, const std::string& fmt,
                          const std::string& ans) {
-  EXPECT_EQ(ans, format(fmt, tp, tz)) << fmt;
-  EXPECT_EQ("xxx " + ans, format("xxx " + fmt, tp, tz));
-  EXPECT_EQ(ans + " yyy", format(fmt + " yyy", tp, tz));
-  EXPECT_EQ("xxx " + ans + " yyy", format("xxx " + fmt + " yyy", tp, tz));
+  EXPECT_EQ(ans, cctz::format(fmt, tp, tz)) << fmt;
+  EXPECT_EQ("xxx " + ans, cctz::format("xxx " + fmt, tp, tz));
+  EXPECT_EQ(ans + " yyy", cctz::format(fmt + " yyy", tp, tz));
+  EXPECT_EQ("xxx " + ans + " yyy", cctz::format("xxx " + fmt + " yyy", tp, tz));
 }
 
 }  // namespace
@@ -79,23 +79,27 @@ TEST(Format, TimePointResolution) {
       chrono::system_clock::from_time_t(1420167845) +
       chrono::milliseconds(123) + chrono::microseconds(456) +
       chrono::nanoseconds(789);
+  EXPECT_EQ("03:04:05.123456789",
+            cctz::format(kFmt, chrono::time_point_cast<chrono::nanoseconds>(t0),
+                         utc));
+  EXPECT_EQ("03:04:05.123456",
+            cctz::format(
+                kFmt, chrono::time_point_cast<chrono::microseconds>(t0), utc));
+  EXPECT_EQ("03:04:05.123",
+            cctz::format(
+                kFmt, chrono::time_point_cast<chrono::milliseconds>(t0), utc));
   EXPECT_EQ(
-      "03:04:05.123456789",
-      format(kFmt, chrono::time_point_cast<chrono::nanoseconds>(t0), utc));
+      "03:04:05",
+      cctz::format(kFmt, chrono::time_point_cast<chrono::seconds>(t0), utc));
   EXPECT_EQ(
-      "03:04:05.123456",
-      format(kFmt, chrono::time_point_cast<chrono::microseconds>(t0), utc));
+      "03:04:05",
+      cctz::format(kFmt, chrono::time_point_cast<cctz::seconds>(t0), utc));
   EXPECT_EQ(
-      "03:04:05.123",
-      format(kFmt, chrono::time_point_cast<chrono::milliseconds>(t0), utc));
-  EXPECT_EQ("03:04:05",
-            format(kFmt, chrono::time_point_cast<chrono::seconds>(t0), utc));
-  EXPECT_EQ("03:04:05",
-            format(kFmt, chrono::time_point_cast<cctz::seconds>(t0), utc));
-  EXPECT_EQ("03:04:00",
-            format(kFmt, chrono::time_point_cast<chrono::minutes>(t0), utc));
-  EXPECT_EQ("03:00:00",
-            format(kFmt, chrono::time_point_cast<chrono::hours>(t0), utc));
+      "03:04:00",
+      cctz::format(kFmt, chrono::time_point_cast<chrono::minutes>(t0), utc));
+  EXPECT_EQ(
+      "03:00:00",
+      cctz::format(kFmt, chrono::time_point_cast<chrono::hours>(t0), utc));
 }
 
 TEST(Format, TimePointExtendedResolution) {
@@ -132,24 +136,24 @@ TEST(Format, Basics) {
   time_point<chrono::nanoseconds> tp = chrono::system_clock::from_time_t(0);
 
   // Starts with a couple basic edge cases.
-  EXPECT_EQ("", format("", tp, tz));
-  EXPECT_EQ(" ", format(" ", tp, tz));
-  EXPECT_EQ("  ", format("  ", tp, tz));
-  EXPECT_EQ("xxx", format("xxx", tp, tz));
+  EXPECT_EQ("", cctz::format("", tp, tz));
+  EXPECT_EQ(" ", cctz::format(" ", tp, tz));
+  EXPECT_EQ("  ", cctz::format("  ", tp, tz));
+  EXPECT_EQ("xxx", cctz::format("xxx", tp, tz));
   std::string big(128, 'x');
-  EXPECT_EQ(big, format(big, tp, tz));
+  EXPECT_EQ(big, cctz::format(big, tp, tz));
   // Cause the 1024-byte buffer to grow.
   std::string bigger(100000, 'x');
-  EXPECT_EQ(bigger, format(bigger, tp, tz));
+  EXPECT_EQ(bigger, cctz::format(bigger, tp, tz));
 
   tp += chrono::hours(13) + chrono::minutes(4) + chrono::seconds(5);
   tp += chrono::milliseconds(6) + chrono::microseconds(7) +
         chrono::nanoseconds(8);
-  EXPECT_EQ("1970-01-01", format("%Y-%m-%d", tp, tz));
-  EXPECT_EQ("13:04:05", format("%H:%M:%S", tp, tz));
-  EXPECT_EQ("13:04:05.006", format("%H:%M:%E3S", tp, tz));
-  EXPECT_EQ("13:04:05.006007", format("%H:%M:%E6S", tp, tz));
-  EXPECT_EQ("13:04:05.006007008", format("%H:%M:%E9S", tp, tz));
+  EXPECT_EQ("1970-01-01", cctz::format("%Y-%m-%d", tp, tz));
+  EXPECT_EQ("13:04:05", cctz::format("%H:%M:%S", tp, tz));
+  EXPECT_EQ("13:04:05.006", cctz::format("%H:%M:%E3S", tp, tz));
+  EXPECT_EQ("13:04:05.006007", cctz::format("%H:%M:%E6S", tp, tz));
+  EXPECT_EQ("13:04:05.006007008", cctz::format("%H:%M:%E9S", tp, tz));
 }
 
 TEST(Format, PosixConversions) {
@@ -270,49 +274,49 @@ TEST(Format, ExtendedSeconds) {
   // No subseconds.
   time_point<chrono::nanoseconds> tp = chrono::system_clock::from_time_t(0);
   tp += chrono::seconds(5);
-  EXPECT_EQ("05", format("%E*S", tp, tz));
-  EXPECT_EQ("05", format("%E0S", tp, tz));
-  EXPECT_EQ("05.0", format("%E1S", tp, tz));
-  EXPECT_EQ("05.00", format("%E2S", tp, tz));
-  EXPECT_EQ("05.000", format("%E3S", tp, tz));
-  EXPECT_EQ("05.0000", format("%E4S", tp, tz));
-  EXPECT_EQ("05.00000", format("%E5S", tp, tz));
-  EXPECT_EQ("05.000000", format("%E6S", tp, tz));
-  EXPECT_EQ("05.0000000", format("%E7S", tp, tz));
-  EXPECT_EQ("05.00000000", format("%E8S", tp, tz));
-  EXPECT_EQ("05.000000000", format("%E9S", tp, tz));
-  EXPECT_EQ("05.0000000000", format("%E10S", tp, tz));
-  EXPECT_EQ("05.00000000000", format("%E11S", tp, tz));
-  EXPECT_EQ("05.000000000000", format("%E12S", tp, tz));
-  EXPECT_EQ("05.0000000000000", format("%E13S", tp, tz));
-  EXPECT_EQ("05.00000000000000", format("%E14S", tp, tz));
-  EXPECT_EQ("05.000000000000000", format("%E15S", tp, tz));
+  EXPECT_EQ("05", cctz::format("%E*S", tp, tz));
+  EXPECT_EQ("05", cctz::format("%E0S", tp, tz));
+  EXPECT_EQ("05.0", cctz::format("%E1S", tp, tz));
+  EXPECT_EQ("05.00", cctz::format("%E2S", tp, tz));
+  EXPECT_EQ("05.000", cctz::format("%E3S", tp, tz));
+  EXPECT_EQ("05.0000", cctz::format("%E4S", tp, tz));
+  EXPECT_EQ("05.00000", cctz::format("%E5S", tp, tz));
+  EXPECT_EQ("05.000000", cctz::format("%E6S", tp, tz));
+  EXPECT_EQ("05.0000000", cctz::format("%E7S", tp, tz));
+  EXPECT_EQ("05.00000000", cctz::format("%E8S", tp, tz));
+  EXPECT_EQ("05.000000000", cctz::format("%E9S", tp, tz));
+  EXPECT_EQ("05.0000000000", cctz::format("%E10S", tp, tz));
+  EXPECT_EQ("05.00000000000", cctz::format("%E11S", tp, tz));
+  EXPECT_EQ("05.000000000000", cctz::format("%E12S", tp, tz));
+  EXPECT_EQ("05.0000000000000", cctz::format("%E13S", tp, tz));
+  EXPECT_EQ("05.00000000000000", cctz::format("%E14S", tp, tz));
+  EXPECT_EQ("05.000000000000000", cctz::format("%E15S", tp, tz));
 
   // With subseconds.
   tp += chrono::milliseconds(6) + chrono::microseconds(7) +
         chrono::nanoseconds(8);
-  EXPECT_EQ("05.006007008", format("%E*S", tp, tz));
-  EXPECT_EQ("05", format("%E0S", tp, tz));
-  EXPECT_EQ("05.0", format("%E1S", tp, tz));
-  EXPECT_EQ("05.00", format("%E2S", tp, tz));
-  EXPECT_EQ("05.006", format("%E3S", tp, tz));
-  EXPECT_EQ("05.0060", format("%E4S", tp, tz));
-  EXPECT_EQ("05.00600", format("%E5S", tp, tz));
-  EXPECT_EQ("05.006007", format("%E6S", tp, tz));
-  EXPECT_EQ("05.0060070", format("%E7S", tp, tz));
-  EXPECT_EQ("05.00600700", format("%E8S", tp, tz));
-  EXPECT_EQ("05.006007008", format("%E9S", tp, tz));
-  EXPECT_EQ("05.0060070080", format("%E10S", tp, tz));
-  EXPECT_EQ("05.00600700800", format("%E11S", tp, tz));
-  EXPECT_EQ("05.006007008000", format("%E12S", tp, tz));
-  EXPECT_EQ("05.0060070080000", format("%E13S", tp, tz));
-  EXPECT_EQ("05.00600700800000", format("%E14S", tp, tz));
-  EXPECT_EQ("05.006007008000000", format("%E15S", tp, tz));
+  EXPECT_EQ("05.006007008", cctz::format("%E*S", tp, tz));
+  EXPECT_EQ("05", cctz::format("%E0S", tp, tz));
+  EXPECT_EQ("05.0", cctz::format("%E1S", tp, tz));
+  EXPECT_EQ("05.00", cctz::format("%E2S", tp, tz));
+  EXPECT_EQ("05.006", cctz::format("%E3S", tp, tz));
+  EXPECT_EQ("05.0060", cctz::format("%E4S", tp, tz));
+  EXPECT_EQ("05.00600", cctz::format("%E5S", tp, tz));
+  EXPECT_EQ("05.006007", cctz::format("%E6S", tp, tz));
+  EXPECT_EQ("05.0060070", cctz::format("%E7S", tp, tz));
+  EXPECT_EQ("05.00600700", cctz::format("%E8S", tp, tz));
+  EXPECT_EQ("05.006007008", cctz::format("%E9S", tp, tz));
+  EXPECT_EQ("05.0060070080", cctz::format("%E10S", tp, tz));
+  EXPECT_EQ("05.00600700800", cctz::format("%E11S", tp, tz));
+  EXPECT_EQ("05.006007008000", cctz::format("%E12S", tp, tz));
+  EXPECT_EQ("05.0060070080000", cctz::format("%E13S", tp, tz));
+  EXPECT_EQ("05.00600700800000", cctz::format("%E14S", tp, tz));
+  EXPECT_EQ("05.006007008000000", cctz::format("%E15S", tp, tz));
 
   // Times before the Unix epoch.
   tp = chrono::system_clock::from_time_t(0) + chrono::microseconds(-1);
   EXPECT_EQ("1969-12-31 23:59:59.999999",
-            format("%Y-%m-%d %H:%M:%E*S", tp, tz));
+            cctz::format("%Y-%m-%d %H:%M:%E*S", tp, tz));
 
   // Here is a "%E*S" case we got wrong for a while.  While the first
   // instant below is correctly rendered as "...:07.333304", the second
@@ -320,10 +324,10 @@ TEST(Format, ExtendedSeconds) {
   tp = chrono::system_clock::from_time_t(0) +
        chrono::microseconds(1395024427333304);
   EXPECT_EQ("2014-03-17 02:47:07.333304",
-            format("%Y-%m-%d %H:%M:%E*S", tp, tz));
+            cctz::format("%Y-%m-%d %H:%M:%E*S", tp, tz));
   tp += chrono::microseconds(1);
   EXPECT_EQ("2014-03-17 02:47:07.333305",
-            format("%Y-%m-%d %H:%M:%E*S", tp, tz));
+            cctz::format("%Y-%m-%d %H:%M:%E*S", tp, tz));
 }
 
 TEST(Format, ExtendedSubeconds) {
@@ -332,49 +336,49 @@ TEST(Format, ExtendedSubeconds) {
   // No subseconds.
   time_point<chrono::nanoseconds> tp = chrono::system_clock::from_time_t(0);
   tp += chrono::seconds(5);
-  EXPECT_EQ("0", format("%E*f", tp, tz));
-  EXPECT_EQ("", format("%E0f", tp, tz));
-  EXPECT_EQ("0", format("%E1f", tp, tz));
-  EXPECT_EQ("00", format("%E2f", tp, tz));
-  EXPECT_EQ("000", format("%E3f", tp, tz));
-  EXPECT_EQ("0000", format("%E4f", tp, tz));
-  EXPECT_EQ("00000", format("%E5f", tp, tz));
-  EXPECT_EQ("000000", format("%E6f", tp, tz));
-  EXPECT_EQ("0000000", format("%E7f", tp, tz));
-  EXPECT_EQ("00000000", format("%E8f", tp, tz));
-  EXPECT_EQ("000000000", format("%E9f", tp, tz));
-  EXPECT_EQ("0000000000", format("%E10f", tp, tz));
-  EXPECT_EQ("00000000000", format("%E11f", tp, tz));
-  EXPECT_EQ("000000000000", format("%E12f", tp, tz));
-  EXPECT_EQ("0000000000000", format("%E13f", tp, tz));
-  EXPECT_EQ("00000000000000", format("%E14f", tp, tz));
-  EXPECT_EQ("000000000000000", format("%E15f", tp, tz));
+  EXPECT_EQ("0", cctz::format("%E*f", tp, tz));
+  EXPECT_EQ("", cctz::format("%E0f", tp, tz));
+  EXPECT_EQ("0", cctz::format("%E1f", tp, tz));
+  EXPECT_EQ("00", cctz::format("%E2f", tp, tz));
+  EXPECT_EQ("000", cctz::format("%E3f", tp, tz));
+  EXPECT_EQ("0000", cctz::format("%E4f", tp, tz));
+  EXPECT_EQ("00000", cctz::format("%E5f", tp, tz));
+  EXPECT_EQ("000000", cctz::format("%E6f", tp, tz));
+  EXPECT_EQ("0000000", cctz::format("%E7f", tp, tz));
+  EXPECT_EQ("00000000", cctz::format("%E8f", tp, tz));
+  EXPECT_EQ("000000000", cctz::format("%E9f", tp, tz));
+  EXPECT_EQ("0000000000", cctz::format("%E10f", tp, tz));
+  EXPECT_EQ("00000000000", cctz::format("%E11f", tp, tz));
+  EXPECT_EQ("000000000000", cctz::format("%E12f", tp, tz));
+  EXPECT_EQ("0000000000000", cctz::format("%E13f", tp, tz));
+  EXPECT_EQ("00000000000000", cctz::format("%E14f", tp, tz));
+  EXPECT_EQ("000000000000000", cctz::format("%E15f", tp, tz));
 
   // With subseconds.
   tp += chrono::milliseconds(6) + chrono::microseconds(7) +
         chrono::nanoseconds(8);
-  EXPECT_EQ("006007008", format("%E*f", tp, tz));
-  EXPECT_EQ("", format("%E0f", tp, tz));
-  EXPECT_EQ("0", format("%E1f", tp, tz));
-  EXPECT_EQ("00", format("%E2f", tp, tz));
-  EXPECT_EQ("006", format("%E3f", tp, tz));
-  EXPECT_EQ("0060", format("%E4f", tp, tz));
-  EXPECT_EQ("00600", format("%E5f", tp, tz));
-  EXPECT_EQ("006007", format("%E6f", tp, tz));
-  EXPECT_EQ("0060070", format("%E7f", tp, tz));
-  EXPECT_EQ("00600700", format("%E8f", tp, tz));
-  EXPECT_EQ("006007008", format("%E9f", tp, tz));
-  EXPECT_EQ("0060070080", format("%E10f", tp, tz));
-  EXPECT_EQ("00600700800", format("%E11f", tp, tz));
-  EXPECT_EQ("006007008000", format("%E12f", tp, tz));
-  EXPECT_EQ("0060070080000", format("%E13f", tp, tz));
-  EXPECT_EQ("00600700800000", format("%E14f", tp, tz));
-  EXPECT_EQ("006007008000000", format("%E15f", tp, tz));
+  EXPECT_EQ("006007008", cctz::format("%E*f", tp, tz));
+  EXPECT_EQ("", cctz::format("%E0f", tp, tz));
+  EXPECT_EQ("0", cctz::format("%E1f", tp, tz));
+  EXPECT_EQ("00", cctz::format("%E2f", tp, tz));
+  EXPECT_EQ("006", cctz::format("%E3f", tp, tz));
+  EXPECT_EQ("0060", cctz::format("%E4f", tp, tz));
+  EXPECT_EQ("00600", cctz::format("%E5f", tp, tz));
+  EXPECT_EQ("006007", cctz::format("%E6f", tp, tz));
+  EXPECT_EQ("0060070", cctz::format("%E7f", tp, tz));
+  EXPECT_EQ("00600700", cctz::format("%E8f", tp, tz));
+  EXPECT_EQ("006007008", cctz::format("%E9f", tp, tz));
+  EXPECT_EQ("0060070080", cctz::format("%E10f", tp, tz));
+  EXPECT_EQ("00600700800", cctz::format("%E11f", tp, tz));
+  EXPECT_EQ("006007008000", cctz::format("%E12f", tp, tz));
+  EXPECT_EQ("0060070080000", cctz::format("%E13f", tp, tz));
+  EXPECT_EQ("00600700800000", cctz::format("%E14f", tp, tz));
+  EXPECT_EQ("006007008000000", cctz::format("%E15f", tp, tz));
 
   // Times before the Unix epoch.
   tp = chrono::system_clock::from_time_t(0) + chrono::microseconds(-1);
   EXPECT_EQ("1969-12-31 23:59:59.999999",
-            format("%Y-%m-%d %H:%M:%S.%E*f", tp, tz));
+            cctz::format("%Y-%m-%d %H:%M:%S.%E*f", tp, tz));
 
   // Here is a "%E*S" case we got wrong for a while.  While the first
   // instant below is correctly rendered as "...:07.333304", the second
@@ -382,10 +386,10 @@ TEST(Format, ExtendedSubeconds) {
   tp = chrono::system_clock::from_time_t(0) +
        chrono::microseconds(1395024427333304);
   EXPECT_EQ("2014-03-17 02:47:07.333304",
-            format("%Y-%m-%d %H:%M:%S.%E*f", tp, tz));
+            cctz::format("%Y-%m-%d %H:%M:%S.%E*f", tp, tz));
   tp += chrono::microseconds(1);
   EXPECT_EQ("2014-03-17 02:47:07.333305",
-            format("%Y-%m-%d %H:%M:%S.%E*f", tp, tz));
+            cctz::format("%Y-%m-%d %H:%M:%S.%E*f", tp, tz));
 }
 
 TEST(Format, CompareExtendSecondsVsSubseconds) {
@@ -401,15 +405,15 @@ TEST(Format, CompareExtendSecondsVsSubseconds) {
   time_point<chrono::nanoseconds> tp = chrono::system_clock::from_time_t(0);
   tp += chrono::seconds(5);
   // ... %E*S and %S.%E*f are different.
-  EXPECT_EQ("05", format(fmt_A("*"), tp, tz));
-  EXPECT_EQ("05.0", format(fmt_B("*"), tp, tz));
+  EXPECT_EQ("05", cctz::format(fmt_A("*"), tp, tz));
+  EXPECT_EQ("05.0", cctz::format(fmt_B("*"), tp, tz));
   // ... %E0S and %S.%E0f are different.
-  EXPECT_EQ("05", format(fmt_A("0"), tp, tz));
-  EXPECT_EQ("05.", format(fmt_B("0"), tp, tz));
+  EXPECT_EQ("05", cctz::format(fmt_A("0"), tp, tz));
+  EXPECT_EQ("05.", cctz::format(fmt_B("0"), tp, tz));
   // ... %E<prec>S and %S.%E<prec>f are the same for prec in [1:15].
   for (int prec = 1; prec <= 15; ++prec) {
-    const std::string a = format(fmt_A(std::to_string(prec)), tp, tz);
-    const std::string b = format(fmt_B(std::to_string(prec)), tp, tz);
+    const std::string a = cctz::format(fmt_A(std::to_string(prec)), tp, tz);
+    const std::string b = cctz::format(fmt_B(std::to_string(prec)), tp, tz);
     EXPECT_EQ(a, b) << "prec=" << prec;
   }
 
@@ -417,15 +421,15 @@ TEST(Format, CompareExtendSecondsVsSubseconds) {
   // ... %E*S and %S.%E*f are the same.
   tp += chrono::milliseconds(6) + chrono::microseconds(7) +
         chrono::nanoseconds(8);
-  EXPECT_EQ("05.006007008", format(fmt_A("*"), tp, tz));
-  EXPECT_EQ("05.006007008", format(fmt_B("*"), tp, tz));
+  EXPECT_EQ("05.006007008", cctz::format(fmt_A("*"), tp, tz));
+  EXPECT_EQ("05.006007008", cctz::format(fmt_B("*"), tp, tz));
   // ... %E0S and %S.%E0f are different.
-  EXPECT_EQ("05", format(fmt_A("0"), tp, tz));
-  EXPECT_EQ("05.", format(fmt_B("0"), tp, tz));
+  EXPECT_EQ("05", cctz::format(fmt_A("0"), tp, tz));
+  EXPECT_EQ("05.", cctz::format(fmt_B("0"), tp, tz));
   // ... %E<prec>S and %S.%E<prec>f are the same for prec in [1:15].
   for (int prec = 1; prec <= 15; ++prec) {
-    const std::string a = format(fmt_A(std::to_string(prec)), tp, tz);
-    const std::string b = format(fmt_B(std::to_string(prec)), tp, tz);
+    const std::string a = cctz::format(fmt_A(std::to_string(prec)), tp, tz);
+    const std::string b = cctz::format(fmt_B(std::to_string(prec)), tp, tz);
     EXPECT_EQ(a, b) << "prec=" << prec;
   }
 }
@@ -598,31 +602,31 @@ TEST(Format, ExtendedYears) {
 
   // %E4Y zero-pads the year to produce at least 4 chars, including the sign.
   auto tp = convert(civil_second(-999, 11, 27, 0, 0, 0), utc);
-  EXPECT_EQ("-9991127", format(e4y_fmt, tp, utc));
+  EXPECT_EQ("-9991127", cctz::format(e4y_fmt, tp, utc));
   tp = convert(civil_second(-99, 11, 27, 0, 0, 0), utc);
-  EXPECT_EQ("-0991127", format(e4y_fmt, tp, utc));
+  EXPECT_EQ("-0991127", cctz::format(e4y_fmt, tp, utc));
   tp = convert(civil_second(-9, 11, 27, 0, 0, 0), utc);
-  EXPECT_EQ("-0091127", format(e4y_fmt, tp, utc));
+  EXPECT_EQ("-0091127", cctz::format(e4y_fmt, tp, utc));
   tp = convert(civil_second(-1, 11, 27, 0, 0, 0), utc);
-  EXPECT_EQ("-0011127", format(e4y_fmt, tp, utc));
+  EXPECT_EQ("-0011127", cctz::format(e4y_fmt, tp, utc));
   tp = convert(civil_second(0, 11, 27, 0, 0, 0), utc);
-  EXPECT_EQ("00001127", format(e4y_fmt, tp, utc));
+  EXPECT_EQ("00001127", cctz::format(e4y_fmt, tp, utc));
   tp = convert(civil_second(1, 11, 27, 0, 0, 0), utc);
-  EXPECT_EQ("00011127", format(e4y_fmt, tp, utc));
+  EXPECT_EQ("00011127", cctz::format(e4y_fmt, tp, utc));
   tp = convert(civil_second(9, 11, 27, 0, 0, 0), utc);
-  EXPECT_EQ("00091127", format(e4y_fmt, tp, utc));
+  EXPECT_EQ("00091127", cctz::format(e4y_fmt, tp, utc));
   tp = convert(civil_second(99, 11, 27, 0, 0, 0), utc);
-  EXPECT_EQ("00991127", format(e4y_fmt, tp, utc));
+  EXPECT_EQ("00991127", cctz::format(e4y_fmt, tp, utc));
   tp = convert(civil_second(999, 11, 27, 0, 0, 0), utc);
-  EXPECT_EQ("09991127", format(e4y_fmt, tp, utc));
+  EXPECT_EQ("09991127", cctz::format(e4y_fmt, tp, utc));
   tp = convert(civil_second(9999, 11, 27, 0, 0, 0), utc);
-  EXPECT_EQ("99991127", format(e4y_fmt, tp, utc));
+  EXPECT_EQ("99991127", cctz::format(e4y_fmt, tp, utc));
 
   // When the year is outside [-999:9999], more than 4 chars are produced.
   tp = convert(civil_second(-1000, 11, 27, 0, 0, 0), utc);
-  EXPECT_EQ("-10001127", format(e4y_fmt, tp, utc));
+  EXPECT_EQ("-10001127", cctz::format(e4y_fmt, tp, utc));
   tp = convert(civil_second(10000, 11, 27, 0, 0, 0), utc);
-  EXPECT_EQ("100001127", format(e4y_fmt, tp, utc));
+  EXPECT_EQ("100001127", cctz::format(e4y_fmt, tp, utc));
 }
 
 TEST(Format, RFC3339Format) {
@@ -631,45 +635,51 @@ TEST(Format, RFC3339Format) {
 
   time_point<chrono::nanoseconds> tp =
       convert(civil_second(1977, 6, 28, 9, 8, 7), tz);
-  EXPECT_EQ("1977-06-28T09:08:07-07:00", format(RFC3339_full, tp, tz));
-  EXPECT_EQ("1977-06-28T09:08:07-07:00", format(RFC3339_sec, tp, tz));
+  EXPECT_EQ("1977-06-28T09:08:07-07:00", cctz::format(RFC3339_full, tp, tz));
+  EXPECT_EQ("1977-06-28T09:08:07-07:00", cctz::format(RFC3339_sec, tp, tz));
 
   tp += chrono::milliseconds(100);
-  EXPECT_EQ("1977-06-28T09:08:07.1-07:00", format(RFC3339_full, tp, tz));
-  EXPECT_EQ("1977-06-28T09:08:07-07:00", format(RFC3339_sec, tp, tz));
+  EXPECT_EQ("1977-06-28T09:08:07.1-07:00", cctz::format(RFC3339_full, tp, tz));
+  EXPECT_EQ("1977-06-28T09:08:07-07:00", cctz::format(RFC3339_sec, tp, tz));
 
   tp += chrono::milliseconds(20);
-  EXPECT_EQ("1977-06-28T09:08:07.12-07:00", format(RFC3339_full, tp, tz));
-  EXPECT_EQ("1977-06-28T09:08:07-07:00", format(RFC3339_sec, tp, tz));
+  EXPECT_EQ("1977-06-28T09:08:07.12-07:00", cctz::format(RFC3339_full, tp, tz));
+  EXPECT_EQ("1977-06-28T09:08:07-07:00", cctz::format(RFC3339_sec, tp, tz));
 
   tp += chrono::milliseconds(3);
-  EXPECT_EQ("1977-06-28T09:08:07.123-07:00", format(RFC3339_full, tp, tz));
-  EXPECT_EQ("1977-06-28T09:08:07-07:00", format(RFC3339_sec, tp, tz));
+  EXPECT_EQ("1977-06-28T09:08:07.123-07:00",
+            cctz::format(RFC3339_full, tp, tz));
+  EXPECT_EQ("1977-06-28T09:08:07-07:00", cctz::format(RFC3339_sec, tp, tz));
 
   tp += chrono::microseconds(400);
-  EXPECT_EQ("1977-06-28T09:08:07.1234-07:00", format(RFC3339_full, tp, tz));
-  EXPECT_EQ("1977-06-28T09:08:07-07:00", format(RFC3339_sec, tp, tz));
+  EXPECT_EQ("1977-06-28T09:08:07.1234-07:00",
+            cctz::format(RFC3339_full, tp, tz));
+  EXPECT_EQ("1977-06-28T09:08:07-07:00", cctz::format(RFC3339_sec, tp, tz));
 
   tp += chrono::microseconds(50);
-  EXPECT_EQ("1977-06-28T09:08:07.12345-07:00", format(RFC3339_full, tp, tz));
-  EXPECT_EQ("1977-06-28T09:08:07-07:00", format(RFC3339_sec, tp, tz));
+  EXPECT_EQ("1977-06-28T09:08:07.12345-07:00",
+            cctz::format(RFC3339_full, tp, tz));
+  EXPECT_EQ("1977-06-28T09:08:07-07:00", cctz::format(RFC3339_sec, tp, tz));
 
   tp += chrono::microseconds(6);
-  EXPECT_EQ("1977-06-28T09:08:07.123456-07:00", format(RFC3339_full, tp, tz));
-  EXPECT_EQ("1977-06-28T09:08:07-07:00", format(RFC3339_sec, tp, tz));
+  EXPECT_EQ("1977-06-28T09:08:07.123456-07:00",
+            cctz::format(RFC3339_full, tp, tz));
+  EXPECT_EQ("1977-06-28T09:08:07-07:00", cctz::format(RFC3339_sec, tp, tz));
 
   tp += chrono::nanoseconds(700);
-  EXPECT_EQ("1977-06-28T09:08:07.1234567-07:00", format(RFC3339_full, tp, tz));
-  EXPECT_EQ("1977-06-28T09:08:07-07:00", format(RFC3339_sec, tp, tz));
+  EXPECT_EQ("1977-06-28T09:08:07.1234567-07:00",
+            cctz::format(RFC3339_full, tp, tz));
+  EXPECT_EQ("1977-06-28T09:08:07-07:00", cctz::format(RFC3339_sec, tp, tz));
 
   tp += chrono::nanoseconds(80);
-  EXPECT_EQ("1977-06-28T09:08:07.12345678-07:00", format(RFC3339_full, tp, tz));
-  EXPECT_EQ("1977-06-28T09:08:07-07:00", format(RFC3339_sec, tp, tz));
+  EXPECT_EQ("1977-06-28T09:08:07.12345678-07:00",
+            cctz::format(RFC3339_full, tp, tz));
+  EXPECT_EQ("1977-06-28T09:08:07-07:00", cctz::format(RFC3339_sec, tp, tz));
 
   tp += chrono::nanoseconds(9);
   EXPECT_EQ("1977-06-28T09:08:07.123456789-07:00",
-            format(RFC3339_full, tp, tz));
-  EXPECT_EQ("1977-06-28T09:08:07-07:00", format(RFC3339_sec, tp, tz));
+            cctz::format(RFC3339_full, tp, tz));
+  EXPECT_EQ("1977-06-28T09:08:07-07:00", cctz::format(RFC3339_sec, tp, tz));
 }
 
 TEST(Format, RFC1123Format) {  // locale specific
@@ -677,36 +687,38 @@ TEST(Format, RFC1123Format) {  // locale specific
   EXPECT_TRUE(load_time_zone("America/Los_Angeles", &tz));
 
   auto tp = convert(civil_second(1977, 6, 28, 9, 8, 7), tz);
-  EXPECT_EQ("Tue, 28 Jun 1977 09:08:07 -0700", format(RFC1123_full, tp, tz));
-  EXPECT_EQ("28 Jun 1977 09:08:07 -0700", format(RFC1123_no_wday, tp, tz));
+  EXPECT_EQ("Tue, 28 Jun 1977 09:08:07 -0700",
+            cctz::format(RFC1123_full, tp, tz));
+  EXPECT_EQ("28 Jun 1977 09:08:07 -0700",
+            cctz::format(RFC1123_no_wday, tp, tz));
 }
 
 TEST(Format, Week) {
   const time_zone utc = utc_time_zone();
 
   auto tp = convert(civil_second(2017, 1, 1, 0, 0, 0), utc);
-  EXPECT_EQ("2017-01-7", format("%Y-%U-%u", tp, utc));
-  EXPECT_EQ("2017-00-0", format("%Y-%W-%w", tp, utc));
+  EXPECT_EQ("2017-01-7", cctz::format("%Y-%U-%u", tp, utc));
+  EXPECT_EQ("2017-00-0", cctz::format("%Y-%W-%w", tp, utc));
 
   tp = convert(civil_second(2017, 12, 31, 0, 0, 0), utc);
-  EXPECT_EQ("2017-53-7", format("%Y-%U-%u", tp, utc));
-  EXPECT_EQ("2017-52-0", format("%Y-%W-%w", tp, utc));
+  EXPECT_EQ("2017-53-7", cctz::format("%Y-%U-%u", tp, utc));
+  EXPECT_EQ("2017-52-0", cctz::format("%Y-%W-%w", tp, utc));
 
   tp = convert(civil_second(2018, 1, 1, 0, 0, 0), utc);
-  EXPECT_EQ("2018-00-1", format("%Y-%U-%u", tp, utc));
-  EXPECT_EQ("2018-01-1", format("%Y-%W-%w", tp, utc));
+  EXPECT_EQ("2018-00-1", cctz::format("%Y-%U-%u", tp, utc));
+  EXPECT_EQ("2018-01-1", cctz::format("%Y-%W-%w", tp, utc));
 
   tp = convert(civil_second(2018, 12, 31, 0, 0, 0), utc);
-  EXPECT_EQ("2018-52-1", format("%Y-%U-%u", tp, utc));
-  EXPECT_EQ("2018-53-1", format("%Y-%W-%w", tp, utc));
+  EXPECT_EQ("2018-52-1", cctz::format("%Y-%U-%u", tp, utc));
+  EXPECT_EQ("2018-53-1", cctz::format("%Y-%W-%w", tp, utc));
 
   tp = convert(civil_second(2019, 1, 1, 0, 0, 0), utc);
-  EXPECT_EQ("2019-00-2", format("%Y-%U-%u", tp, utc));
-  EXPECT_EQ("2019-00-2", format("%Y-%W-%w", tp, utc));
+  EXPECT_EQ("2019-00-2", cctz::format("%Y-%U-%u", tp, utc));
+  EXPECT_EQ("2019-00-2", cctz::format("%Y-%W-%w", tp, utc));
 
   tp = convert(civil_second(2019, 12, 31, 0, 0, 0), utc);
-  EXPECT_EQ("2019-52-2", format("%Y-%U-%u", tp, utc));
-  EXPECT_EQ("2019-52-2", format("%Y-%W-%w", tp, utc));
+  EXPECT_EQ("2019-52-2", cctz::format("%Y-%U-%u", tp, utc));
+  EXPECT_EQ("2019-52-2", cctz::format("%Y-%W-%w", tp, utc));
 }
 
 //
@@ -719,39 +731,39 @@ TEST(Parse, TimePointResolution) {
 
   time_point<chrono::nanoseconds> tp_ns;
   EXPECT_TRUE(parse(kFmt, "03:04:05.123456789", utc, &tp_ns));
-  EXPECT_EQ("03:04:05.123456789", format(kFmt, tp_ns, utc));
+  EXPECT_EQ("03:04:05.123456789", cctz::format(kFmt, tp_ns, utc));
   EXPECT_TRUE(parse(kFmt, "03:04:05.123456", utc, &tp_ns));
-  EXPECT_EQ("03:04:05.123456", format(kFmt, tp_ns, utc));
+  EXPECT_EQ("03:04:05.123456", cctz::format(kFmt, tp_ns, utc));
 
   time_point<chrono::microseconds> tp_us;
   EXPECT_TRUE(parse(kFmt, "03:04:05.123456789", utc, &tp_us));
-  EXPECT_EQ("03:04:05.123456", format(kFmt, tp_us, utc));
+  EXPECT_EQ("03:04:05.123456", cctz::format(kFmt, tp_us, utc));
   EXPECT_TRUE(parse(kFmt, "03:04:05.123456", utc, &tp_us));
-  EXPECT_EQ("03:04:05.123456", format(kFmt, tp_us, utc));
+  EXPECT_EQ("03:04:05.123456", cctz::format(kFmt, tp_us, utc));
   EXPECT_TRUE(parse(kFmt, "03:04:05.123", utc, &tp_us));
-  EXPECT_EQ("03:04:05.123", format(kFmt, tp_us, utc));
+  EXPECT_EQ("03:04:05.123", cctz::format(kFmt, tp_us, utc));
 
   time_point<chrono::milliseconds> tp_ms;
   EXPECT_TRUE(parse(kFmt, "03:04:05.123456", utc, &tp_ms));
-  EXPECT_EQ("03:04:05.123", format(kFmt, tp_ms, utc));
+  EXPECT_EQ("03:04:05.123", cctz::format(kFmt, tp_ms, utc));
   EXPECT_TRUE(parse(kFmt, "03:04:05.123", utc, &tp_ms));
-  EXPECT_EQ("03:04:05.123", format(kFmt, tp_ms, utc));
+  EXPECT_EQ("03:04:05.123", cctz::format(kFmt, tp_ms, utc));
   EXPECT_TRUE(parse(kFmt, "03:04:05", utc, &tp_ms));
-  EXPECT_EQ("03:04:05", format(kFmt, tp_ms, utc));
+  EXPECT_EQ("03:04:05", cctz::format(kFmt, tp_ms, utc));
 
   time_point<chrono::seconds> tp_s;
   EXPECT_TRUE(parse(kFmt, "03:04:05.123", utc, &tp_s));
-  EXPECT_EQ("03:04:05", format(kFmt, tp_s, utc));
+  EXPECT_EQ("03:04:05", cctz::format(kFmt, tp_s, utc));
   EXPECT_TRUE(parse(kFmt, "03:04:05", utc, &tp_s));
-  EXPECT_EQ("03:04:05", format(kFmt, tp_s, utc));
+  EXPECT_EQ("03:04:05", cctz::format(kFmt, tp_s, utc));
 
   time_point<chrono::minutes> tp_m;
   EXPECT_TRUE(parse(kFmt, "03:04:05", utc, &tp_m));
-  EXPECT_EQ("03:04:00", format(kFmt, tp_m, utc));
+  EXPECT_EQ("03:04:00", cctz::format(kFmt, tp_m, utc));
 
   time_point<chrono::hours> tp_h;
   EXPECT_TRUE(parse(kFmt, "03:04:05", utc, &tp_h));
-  EXPECT_EQ("03:00:00", format(kFmt, tp_h, utc));
+  EXPECT_EQ("03:00:00", cctz::format(kFmt, tp_h, utc));
 }
 
 TEST(Parse, TimePointExtendedResolution) {
@@ -1543,7 +1555,7 @@ TEST(Parse, TimePointOverflow) {
       parse(RFC3339_full, "2262-04-11T23:47:16.8547758079+00:00", utc, &tp));
   EXPECT_EQ(tp, time_point<D>::max());
   EXPECT_EQ("2262-04-11T23:47:16.854775807+00:00",
-            format(RFC3339_full, tp, utc));
+            cctz::format(RFC3339_full, tp, utc));
 #if 0
   // TODO(#199): Will fail until cctz::parse() properly detects overflow.
   EXPECT_FALSE(
@@ -1552,7 +1564,7 @@ TEST(Parse, TimePointOverflow) {
       parse(RFC3339_full, "1677-09-21T00:12:43.1452241920+00:00", utc, &tp));
   EXPECT_EQ(tp, time_point<D>::min());
   EXPECT_EQ("1677-09-21T00:12:43.145224192+00:00",
-            format(RFC3339_full, tp, utc));
+            cctz::format(RFC3339_full, tp, utc));
   EXPECT_FALSE(
       parse(RFC3339_full, "1677-09-21T00:12:43.1452241919+00:00", utc, &tp));
 #endif
@@ -1562,12 +1574,12 @@ TEST(Parse, TimePointOverflow) {
 
   EXPECT_TRUE(parse(RFC3339_full, "1970-01-01T00:02:07.9+00:00", utc, &stp));
   EXPECT_EQ(stp, time_point<DS>::max());
-  EXPECT_EQ("1970-01-01T00:02:07+00:00", format(RFC3339_full, stp, utc));
+  EXPECT_EQ("1970-01-01T00:02:07+00:00", cctz::format(RFC3339_full, stp, utc));
   EXPECT_FALSE(parse(RFC3339_full, "1970-01-01T00:02:08+00:00", utc, &stp));
 
   EXPECT_TRUE(parse(RFC3339_full, "1969-12-31T23:57:52+00:00", utc, &stp));
   EXPECT_EQ(stp, time_point<DS>::min());
-  EXPECT_EQ("1969-12-31T23:57:52+00:00", format(RFC3339_full, stp, utc));
+  EXPECT_EQ("1969-12-31T23:57:52+00:00", cctz::format(RFC3339_full, stp, utc));
   EXPECT_FALSE(parse(RFC3339_full, "1969-12-31T23:57:51.9+00:00", utc, &stp));
 
   using DM = chrono::duration<std::int8_t, chrono::minutes::period>;
@@ -1575,12 +1587,12 @@ TEST(Parse, TimePointOverflow) {
 
   EXPECT_TRUE(parse(RFC3339_full, "1970-01-01T02:07:59+00:00", utc, &mtp));
   EXPECT_EQ(mtp, time_point<DM>::max());
-  EXPECT_EQ("1970-01-01T02:07:00+00:00", format(RFC3339_full, mtp, utc));
+  EXPECT_EQ("1970-01-01T02:07:00+00:00", cctz::format(RFC3339_full, mtp, utc));
   EXPECT_FALSE(parse(RFC3339_full, "1970-01-01T02:08:00+00:00", utc, &mtp));
 
   EXPECT_TRUE(parse(RFC3339_full, "1969-12-31T21:52:00+00:00", utc, &mtp));
   EXPECT_EQ(mtp, time_point<DM>::min());
-  EXPECT_EQ("1969-12-31T21:52:00+00:00", format(RFC3339_full, mtp, utc));
+  EXPECT_EQ("1969-12-31T21:52:00+00:00", cctz::format(RFC3339_full, mtp, utc));
   EXPECT_FALSE(parse(RFC3339_full, "1969-12-31T21:51:59+00:00", utc, &mtp));
 }
 
@@ -1594,7 +1606,7 @@ TEST(Parse, TimePointOverflowFloor) {
       parse(RFC3339_full, "294247-01-10T04:00:54.7758079+00:00", utc, &tp));
   EXPECT_EQ(tp, time_point<D>::max());
   EXPECT_EQ("294247-01-10T04:00:54.775807+00:00",
-            format(RFC3339_full, tp, utc));
+            cctz::format(RFC3339_full, tp, utc));
 #if 0
   // TODO(#199): Will fail until cctz::parse() properly detects overflow.
   EXPECT_FALSE(
@@ -1603,7 +1615,7 @@ TEST(Parse, TimePointOverflowFloor) {
       parse(RFC3339_full, "-290308-12-21T19:59:05.2241920+00:00", utc, &tp));
   EXPECT_EQ(tp, time_point<D>::min());
   EXPECT_EQ("-290308-12-21T19:59:05.224192+00:00",
-            format(RFC3339_full, tp, utc));
+            cctz::format(RFC3339_full, tp, utc));
   EXPECT_FALSE(
       parse(RFC3339_full, "-290308-12-21T19:59:05.2241919+00:00", utc, &tp));
 #endif
@@ -1622,7 +1634,7 @@ TEST(FormatParse, RoundTrip) {
   // RFC3339, which renders subseconds.
   {
     time_point<chrono::nanoseconds> out;
-    const std::string s = format(RFC3339_full, in + subseconds, lax);
+    const std::string s = cctz::format(RFC3339_full, in + subseconds, lax);
     EXPECT_TRUE(parse(RFC3339_full, s, lax, &out)) << s;
     EXPECT_EQ(in + subseconds, out);  // RFC3339_full includes %Ez
   }
@@ -1630,7 +1642,7 @@ TEST(FormatParse, RoundTrip) {
   // RFC1123, which only does whole seconds.
   {
     time_point<chrono::nanoseconds> out;
-    const std::string s = format(RFC1123_full, in, lax);
+    const std::string s = cctz::format(RFC1123_full, in, lax);
     EXPECT_TRUE(parse(RFC1123_full, s, lax, &out)) << s;
     EXPECT_EQ(in, out);  // RFC1123_full includes %z
   }
@@ -1644,7 +1656,7 @@ TEST(FormatParse, RoundTrip) {
   {
     time_point<chrono::nanoseconds> out;
     time_zone utc = utc_time_zone();
-    const std::string s = format("%c", in, utc);
+    const std::string s = cctz::format("%c", in, utc);
     EXPECT_TRUE(parse("%c", s, utc, &out)) << s;
     EXPECT_EQ(in, out);
   }
@@ -1654,7 +1666,7 @@ TEST(FormatParse, RoundTrip) {
 TEST(FormatParse, RoundTripDistantFuture) {
   const time_zone utc = utc_time_zone();
   const time_point<cctz::seconds> in = time_point<cctz::seconds>::max();
-  const std::string s = format(RFC3339_full, in, utc);
+  const std::string s = cctz::format(RFC3339_full, in, utc);
   time_point<cctz::seconds> out;
   EXPECT_TRUE(parse(RFC3339_full, s, utc, &out)) << s;
   EXPECT_EQ(in, out);
@@ -1663,7 +1675,7 @@ TEST(FormatParse, RoundTripDistantFuture) {
 TEST(FormatParse, RoundTripDistantPast) {
   const time_zone utc = utc_time_zone();
   const time_point<cctz::seconds> in = time_point<cctz::seconds>::min();
-  const std::string s = format(RFC3339_full, in, utc);
+  const std::string s = cctz::format(RFC3339_full, in, utc);
   time_point<cctz::seconds> out;
   EXPECT_TRUE(parse(RFC3339_full, s, utc, &out)) << s;
   EXPECT_EQ(in, out);

--- a/src/time_zone_lookup_test.cc
+++ b/src/time_zone_lookup_test.cc
@@ -905,19 +905,19 @@ TEST(MakeTime, TimePointResolution) {
   const time_zone utc = utc_time_zone();
   const time_point<chrono::nanoseconds> tp_ns =
       convert(civil_second(2015, 1, 2, 3, 4, 5), utc);
-  EXPECT_EQ("04:05", format("%M:%E*S", tp_ns, utc));
+  EXPECT_EQ("04:05", cctz::format("%M:%E*S", tp_ns, utc));
   const time_point<chrono::microseconds> tp_us =
       convert(civil_second(2015, 1, 2, 3, 4, 5), utc);
-  EXPECT_EQ("04:05", format("%M:%E*S", tp_us, utc));
+  EXPECT_EQ("04:05", cctz::format("%M:%E*S", tp_us, utc));
   const time_point<chrono::milliseconds> tp_ms =
       convert(civil_second(2015, 1, 2, 3, 4, 5), utc);
-  EXPECT_EQ("04:05", format("%M:%E*S", tp_ms, utc));
+  EXPECT_EQ("04:05", cctz::format("%M:%E*S", tp_ms, utc));
   const time_point<chrono::seconds> tp_s =
       convert(civil_second(2015, 1, 2, 3, 4, 5), utc);
-  EXPECT_EQ("04:05", format("%M:%E*S", tp_s, utc));
+  EXPECT_EQ("04:05", cctz::format("%M:%E*S", tp_s, utc));
   const time_point<cctz::seconds> tp_s64 =
       convert(civil_second(2015, 1, 2, 3, 4, 5), utc);
-  EXPECT_EQ("04:05", format("%M:%E*S", tp_s64, utc));
+  EXPECT_EQ("04:05", cctz::format("%M:%E*S", tp_s64, utc));
 
   // These next two require chrono::time_point_cast because the conversion
   // from a resolution of seconds (the return value of convert()) to a
@@ -925,11 +925,11 @@ TEST(MakeTime, TimePointResolution) {
   const time_point<chrono::minutes> tp_m =
       chrono::time_point_cast<chrono::minutes>(
           convert(civil_second(2015, 1, 2, 3, 4, 5), utc));
-  EXPECT_EQ("04:00", format("%M:%E*S", tp_m, utc));
+  EXPECT_EQ("04:00", cctz::format("%M:%E*S", tp_m, utc));
   const time_point<chrono::hours> tp_h =
       chrono::time_point_cast<chrono::hours>(
           convert(civil_second(2015, 1, 2, 3, 4, 5), utc));
-  EXPECT_EQ("00:00", format("%M:%E*S", tp_h, utc));
+  EXPECT_EQ("00:00", cctz::format("%M:%E*S", tp_h, utc));
 }
 
 TEST(MakeTime, Normalization) {
@@ -955,9 +955,11 @@ TEST(MakeTime, SysSecondsLimits) {
 
   // Approach the maximal time_point<cctz::seconds> value from below.
   tp = convert(civil_second(292277026596, 12, 4, 15, 30, 6), utc);
-  EXPECT_EQ("292277026596-12-04T15:30:06+00:00", format(RFC3339, tp, utc));
+  EXPECT_EQ("292277026596-12-04T15:30:06+00:00",
+            cctz::format(RFC3339, tp, utc));
   tp = convert(civil_second(292277026596, 12, 4, 15, 30, 7), utc);
-  EXPECT_EQ("292277026596-12-04T15:30:07+00:00", format(RFC3339, tp, utc));
+  EXPECT_EQ("292277026596-12-04T15:30:07+00:00",
+            cctz::format(RFC3339, tp, utc));
   EXPECT_EQ(time_point<cctz::seconds>::max(), tp);
   tp = convert(civil_second(292277026596, 12, 4, 15, 30, 8), utc);
   EXPECT_EQ(time_point<cctz::seconds>::max(), tp);
@@ -966,7 +968,8 @@ TEST(MakeTime, SysSecondsLimits) {
 
   // Checks that we can also get the maximal value for a far-east zone.
   tp = convert(civil_second(292277026596, 12, 5, 5, 30, 7), east);
-  EXPECT_EQ("292277026596-12-05T05:30:07+14:00", format(RFC3339, tp, east));
+  EXPECT_EQ("292277026596-12-05T05:30:07+14:00",
+            cctz::format(RFC3339, tp, east));
   EXPECT_EQ(time_point<cctz::seconds>::max(), tp);
   tp = convert(civil_second(292277026596, 12, 5, 5, 30, 8), east);
   EXPECT_EQ(time_point<cctz::seconds>::max(), tp);
@@ -975,7 +978,8 @@ TEST(MakeTime, SysSecondsLimits) {
 
   // Checks that we can also get the maximal value for a far-west zone.
   tp = convert(civil_second(292277026596, 12, 4, 1, 30, 7), west);
-  EXPECT_EQ("292277026596-12-04T01:30:07-14:00", format(RFC3339, tp, west));
+  EXPECT_EQ("292277026596-12-04T01:30:07-14:00",
+            cctz::format(RFC3339, tp, west));
   EXPECT_EQ(time_point<cctz::seconds>::max(), tp);
   tp = convert(civil_second(292277026596, 12, 4, 7, 30, 8), west);
   EXPECT_EQ(time_point<cctz::seconds>::max(), tp);
@@ -984,9 +988,11 @@ TEST(MakeTime, SysSecondsLimits) {
 
   // Approach the minimal time_point<cctz::seconds> value from above.
   tp = convert(civil_second(-292277022657, 1, 27, 8, 29, 53), utc);
-  EXPECT_EQ("-292277022657-01-27T08:29:53+00:00", format(RFC3339, tp, utc));
+  EXPECT_EQ("-292277022657-01-27T08:29:53+00:00",
+            cctz::format(RFC3339, tp, utc));
   tp = convert(civil_second(-292277022657, 1, 27, 8, 29, 52), utc);
-  EXPECT_EQ("-292277022657-01-27T08:29:52+00:00", format(RFC3339, tp, utc));
+  EXPECT_EQ("-292277022657-01-27T08:29:52+00:00",
+            cctz::format(RFC3339, tp, utc));
   EXPECT_EQ(time_point<cctz::seconds>::min(), tp);
   tp = convert(civil_second(-292277022657, 1, 27, 8, 29, 51), utc);
   EXPECT_EQ(time_point<cctz::seconds>::min(), tp);
@@ -995,7 +1001,8 @@ TEST(MakeTime, SysSecondsLimits) {
 
   // Checks that we can also get the minimal value for a far-east zone.
   tp = convert(civil_second(-292277022657, 1, 27, 22, 29, 52), east);
-  EXPECT_EQ("-292277022657-01-27T22:29:52+14:00", format(RFC3339, tp, east));
+  EXPECT_EQ("-292277022657-01-27T22:29:52+14:00",
+            cctz::format(RFC3339, tp, east));
   EXPECT_EQ(time_point<cctz::seconds>::min(), tp);
   tp = convert(civil_second(-292277022657, 1, 27, 22, 29, 51), east);
   EXPECT_EQ(time_point<cctz::seconds>::min(), tp);
@@ -1004,7 +1011,8 @@ TEST(MakeTime, SysSecondsLimits) {
 
   // Checks that we can also get the minimal value for a far-west zone.
   tp = convert(civil_second(-292277022657, 1, 26, 18, 29, 52), west);
-  EXPECT_EQ("-292277022657-01-26T18:29:52-14:00", format(RFC3339, tp, west));
+  EXPECT_EQ("-292277022657-01-26T18:29:52-14:00",
+            cctz::format(RFC3339, tp, west));
   EXPECT_EQ(time_point<cctz::seconds>::min(), tp);
   tp = convert(civil_second(-292277022657, 1, 26, 18, 29, 51), west);
   EXPECT_EQ(time_point<cctz::seconds>::min(), tp);
@@ -1024,14 +1032,16 @@ TEST(MakeTime, SysSecondsLimits) {
 #if defined(__FreeBSD__) || defined(__OpenBSD__)
     // The BSD gmtime_r() fails on extreme positive tm_year values.
 #else
-    EXPECT_EQ("2147485547-12-31T23:59:59+00:00", format(RFC3339, tp, cut));
+    EXPECT_EQ("2147485547-12-31T23:59:59+00:00",
+              cctz::format(RFC3339, tp, cut));
 #endif
     const year_t min_tm_year = year_t{std::numeric_limits<int>::min()} + 1900;
     tp = convert(civil_second(min_tm_year, 1, 1, 0, 0, 0), cut);
 #if defined(__Fuchsia__)
     // Fuchsia's gmtime_r() fails on extreme negative values (fxbug.dev/78527).
 #else
-    EXPECT_EQ("-2147481748-01-01T00:00:00+00:00", format(RFC3339, tp, cut));
+    EXPECT_EQ("-2147481748-01-01T00:00:00+00:00",
+              cctz::format(RFC3339, tp, cut));
 #endif
 #endif
   }


### PR DESCRIPTION
When cctz is imported into Abseil in a nested namespace (absl::time_internal::cctz), GCC 13 considers unqualified calls to cctz::format to be ambiguous with C++20's std::format.

I tried adding a using declaration at the top of the files, but that didn't work.