### PR TITLE
Fully qualify another instance of cctz::format()

### DIFF
--- a/src/time_zone_format_test.cc
+++ b/src/time_zone_format_test.cc
@@ -208,7 +208,7 @@ TEST(Format, LocaleSpecific) {
   TestFormatSpecifier(tp, tz, "%B", "January");
 
   // %c should at least produce the numeric year and time-of-day.
-  const std::string s = format("%c", tp, utc_time_zone());
+  const std::string s = cctz::format("%c", tp, utc_time_zone());
   EXPECT_THAT(s, testing::HasSubstr("1970"));
   EXPECT_THAT(s, testing::HasSubstr("00:00:00"));
 


### PR DESCRIPTION
Fully qualify another instance of cctz::format() in time_zone_format_test.cc

This is a follow-up to 8b81c2e5cec44f2f9147a9ece35f2fa1fb407049.

Tested during the Abseil import.