### PR TITLE
Fix sign-conversion warning

### DIFF
--- a/src/time_zone_lookup.cc
+++ b/src/time_zone_lookup.cc
@@ -143,11 +143,12 @@ std::string win32_local_time_zone(const HMODULE combase) {
     UINT32 wlen;
     const PCWSTR tz_wstr = windows_get_string_raw_buffer(tz_hstr, &wlen);
     if (tz_wstr) {
-      const int size = WideCharToMultiByte(CP_UTF8, 0, tz_wstr, wlen, nullptr,
-                                           0, nullptr, nullptr);
-      result.resize(size);
-      WideCharToMultiByte(CP_UTF8, 0, tz_wstr, wlen, &result[0], size,
-                          nullptr, nullptr);
+      const int size =
+          WideCharToMultiByte(CP_UTF8, 0, tz_wstr, static_cast<int>(wlen),
+                              nullptr, 0, nullptr, nullptr);
+      result.resize(static_cast<size_t>(size));
+      WideCharToMultiByte(CP_UTF8, 0, tz_wstr, static_cast<int>(wlen),
+                          &result[0], size, nullptr, nullptr);
     }
     windows_delete_string(tz_hstr);
   }


### PR DESCRIPTION
Add explicit static_cast UINT32 -> int and int -> size_t to support comiling cctz with -Wsign-conversion