### PR TITLE
Streamline time_zone::Impl::UTC to bypass general LoadTimeZone().

### DIFF
--- a/src/time_zone_if.cc
+++ b/src/time_zone_if.cc
@@ -18,6 +18,8 @@
 
 namespace cctz {
 
+std::unique_ptr<TimeZoneIf> TimeZoneIf::UTC() { return TimeZoneInfo::UTC(); }
+
 std::unique_ptr<TimeZoneIf> TimeZoneIf::Load(const std::string& name) {
   // Support "libc:localtime" and "libc:*" to access the legacy
   // localtime and UTC support respectively from the C library.

--- a/src/time_zone_if.h
+++ b/src/time_zone_if.h
@@ -29,7 +29,8 @@ namespace cctz {
 // Subclasses implement the functions for civil-time conversions in the zone.
 class TimeZoneIf {
  public:
-  // A factory function for TimeZoneIf implementations.
+  // Factory functions for TimeZoneIf implementations.
+  static std::unique_ptr<TimeZoneIf> UTC();
   static std::unique_ptr<TimeZoneIf> Load(const std::string& name);
 
   virtual ~TimeZoneIf();

--- a/src/time_zone_impl.cc
+++ b/src/time_zone_impl.cc
@@ -42,9 +42,7 @@ std::mutex& TimeZoneMutex() {
 
 }  // namespace
 
-time_zone time_zone::Impl::UTC() {
-  return time_zone(UTCImpl());
-}
+time_zone time_zone::Impl::UTC() { return time_zone(UTCImpl()); }
 
 bool time_zone::Impl::LoadTimeZone(const std::string& name, time_zone* tz) {
   const Impl* const utc_impl = UTCImpl();
@@ -100,12 +98,10 @@ void time_zone::Impl::ClearTimeZoneMapTestOnly() {
 time_zone::Impl::Impl(const std::string& name)
     : name_(name), zone_(TimeZoneIf::Load(name_)) {}
 
-time_zone::Impl::Impl(const std::string& name, std::unique_ptr<TimeZoneIf> zone)
-    : name_(name), zone_(std::move(zone)) {}
+time_zone::Impl::Impl() : name_("UTC"), zone_(TimeZoneIf::UTC()) {}
 
 const time_zone::Impl* time_zone::Impl::UTCImpl() {
-  static const Impl* utc_impl = new Impl(
-      "UTC", std::unique_ptr<TimeZoneIf>(new TimeZoneInfo(seconds::zero())));
+  static const Impl* utc_impl = new Impl;  // never fails
   return utc_impl;
 }
 

--- a/src/time_zone_impl.cc
+++ b/src/time_zone_impl.cc
@@ -100,8 +100,12 @@ void time_zone::Impl::ClearTimeZoneMapTestOnly() {
 time_zone::Impl::Impl(const std::string& name)
     : name_(name), zone_(TimeZoneIf::Load(name_)) {}
 
+time_zone::Impl::Impl(const std::string& name, std::unique_ptr<TimeZoneIf> zone)
+    : name_(name), zone_(std::move(zone)) {}
+
 const time_zone::Impl* time_zone::Impl::UTCImpl() {
-  static const Impl* utc_impl = new Impl("UTC");  // never fails
+  static const Impl* utc_impl = new Impl(
+      "UTC", std::unique_ptr<TimeZoneIf>(new TimeZoneInfo(seconds::zero())));
   return utc_impl;
 }
 

--- a/src/time_zone_impl.cc
+++ b/src/time_zone_impl.cc
@@ -42,7 +42,9 @@ std::mutex& TimeZoneMutex() {
 
 }  // namespace
 
-time_zone time_zone::Impl::UTC() { return time_zone(UTCImpl()); }
+time_zone time_zone::Impl::UTC() {
+  return time_zone(UTCImpl());
+}
 
 bool time_zone::Impl::LoadTimeZone(const std::string& name, time_zone* tz) {
   const Impl* const utc_impl = UTCImpl();

--- a/src/time_zone_impl.h
+++ b/src/time_zone_impl.h
@@ -75,6 +75,7 @@ class time_zone::Impl {
 
  private:
   explicit Impl(const std::string& name);
+  Impl(const std::string& name, std::unique_ptr<TimeZoneIf> zone);
   static const Impl* UTCImpl();
 
   const std::string name_;

--- a/src/time_zone_impl.h
+++ b/src/time_zone_impl.h
@@ -74,8 +74,8 @@ class time_zone::Impl {
   std::string Description() const { return zone_->Description(); }
 
  private:
+  Impl();
   explicit Impl(const std::string& name);
-  Impl(const std::string& name, std::unique_ptr<TimeZoneIf> zone);
   static const Impl* UTCImpl();
 
   const std::string name_;

--- a/src/time_zone_info.cc
+++ b/src/time_zone_info.cc
@@ -406,12 +406,6 @@ bool TimeZoneInfo::ExtendTransitions() {
   return true;
 }
 
-std::unique_ptr<TimeZoneInfo> TimeZoneInfo::UTC() {
-  auto zone = std::unique_ptr<TimeZoneInfo>(new TimeZoneInfo);
-  zone->ResetToBuiltinUTC(seconds::zero());
-  return zone;
-}
-
 bool TimeZoneInfo::Load(ZoneInfoSource* zip) {
   // Read and validate the header.
   tzhead tzh;
@@ -813,6 +807,12 @@ std::unique_ptr<ZoneInfoSource> FuchsiaZoneInfoSource::Open(
 }
 
 }  // namespace
+
+std::unique_ptr<TimeZoneInfo> TimeZoneInfo::UTC() {
+  auto zone = std::unique_ptr<TimeZoneInfo>(new TimeZoneInfo);
+  zone->ResetToBuiltinUTC(seconds::zero());
+  return zone;
+}
 
 bool TimeZoneInfo::Load(const std::string& name) {
   // We can ensure that the loading of UTC or any other fixed-offset

--- a/src/time_zone_info.cc
+++ b/src/time_zone_info.cc
@@ -808,6 +808,8 @@ std::unique_ptr<ZoneInfoSource> FuchsiaZoneInfoSource::Open(
 
 }  // namespace
 
+TimeZoneInfo::TimeZoneInfo(const seconds& offset) { ResetToBuiltinUTC(offset); }
+
 bool TimeZoneInfo::Load(const std::string& name) {
   // We can ensure that the loading of UTC or any other fixed-offset
   // zone never fails because the simple, fixed-offset state can be

--- a/src/time_zone_info.cc
+++ b/src/time_zone_info.cc
@@ -406,6 +406,12 @@ bool TimeZoneInfo::ExtendTransitions() {
   return true;
 }
 
+std::unique_ptr<TimeZoneInfo> TimeZoneInfo::UTC() {
+  auto zone = std::unique_ptr<TimeZoneInfo>(new TimeZoneInfo);
+  zone->ResetToBuiltinUTC(seconds::zero());
+  return zone;
+}
+
 bool TimeZoneInfo::Load(ZoneInfoSource* zip) {
   // Read and validate the header.
   tzhead tzh;
@@ -807,8 +813,6 @@ std::unique_ptr<ZoneInfoSource> FuchsiaZoneInfoSource::Open(
 }
 
 }  // namespace
-
-TimeZoneInfo::TimeZoneInfo(const seconds& offset) { ResetToBuiltinUTC(offset); }
 
 bool TimeZoneInfo::Load(const std::string& name) {
   // We can ensure that the loading of UTC or any other fixed-offset

--- a/src/time_zone_info.h
+++ b/src/time_zone_info.h
@@ -62,8 +62,6 @@ struct TransitionType {
 class TimeZoneInfo : public TimeZoneIf {
  public:
   TimeZoneInfo() = default;
-  // Initialize as a fixed UTC offset.
-  explicit TimeZoneInfo(const seconds& offset);
   TimeZoneInfo(const TimeZoneInfo&) = delete;
   TimeZoneInfo& operator=(const TimeZoneInfo&) = delete;
 

--- a/src/time_zone_info.h
+++ b/src/time_zone_info.h
@@ -18,6 +18,7 @@
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -65,6 +66,8 @@ class TimeZoneInfo : public TimeZoneIf {
   explicit TimeZoneInfo(const seconds& offset);
   TimeZoneInfo(const TimeZoneInfo&) = delete;
   TimeZoneInfo& operator=(const TimeZoneInfo&) = delete;
+
+  static std::unique_ptr<TimeZoneInfo> UTC();
 
   // Loads the zoneinfo for the given name, returning true if successful.
   bool Load(const std::string& name);

--- a/src/time_zone_info.h
+++ b/src/time_zone_info.h
@@ -61,6 +61,8 @@ struct TransitionType {
 class TimeZoneInfo : public TimeZoneIf {
  public:
   TimeZoneInfo() = default;
+  // Initialize as a fixed UTC offset.
+  explicit TimeZoneInfo(const seconds& offset);
   TimeZoneInfo(const TimeZoneInfo&) = delete;
   TimeZoneInfo& operator=(const TimeZoneInfo&) = delete;
 


### PR DESCRIPTION
This can allow environments like Emscripten WebAssembly to strip LoadTimeZone and all of the transitive filesystem code for loading timezones when only UTC is used.