### PR TITLE
Add VxWorks support

### DIFF
--- a/src/time_zone_format.cc
+++ b/src/time_zone_format.cc
@@ -13,8 +13,9 @@
 //   limitations under the License.
 
 #if !defined(HAS_STRPTIME)
-# if !defined(_MSC_VER) && !defined(__MINGW32__)
+# if !defined(_MSC_VER) && !defined(__MINGW32__) && !defined(__VXWORKS__)
 #  define HAS_STRPTIME 1  // assume everyone has strptime() except windows
+                          // and VxWorks
 # endif
 #endif
 

--- a/src/time_zone_libc.cc
+++ b/src/time_zone_libc.cc
@@ -67,6 +67,16 @@ auto tm_zone(const std::tm& tm) -> decltype(tzname[0]) {
   const bool is_dst = tm.tm_isdst > 0;
   return tzname[is_dst];
 }
+#elif defined(__VXWORKS__)
+// Uses the globals: 'timezone' and 'tzname'.
+auto tm_gmtoff(const std::tm& tm) -> decltype(timezone + 0) {
+  const bool is_dst = tm.tm_isdst > 0;
+  return timezone + (is_dst ? 60 * 60 : 0);
+}
+auto tm_zone(const std::tm& tm) -> decltype(tzname[0]) {
+  const bool is_dst = tm.tm_isdst > 0;
+  return tzname[is_dst];
+}
 #else
 // Adapt to different spellings of the struct std::tm extension fields.
 #if defined(tm_gmtoff)


### PR DESCRIPTION
This PR adds VxWorks support.

A little code is changed for:
strptime() is not supported by VxWorks.
The time zone variables in VxWorks are: timezone and tzname.