### PR TITLE
Add factory functions for named time zones

### DIFF
--- a/src/time_zone_format.cc
+++ b/src/time_zone_format.cc
@@ -14,14 +14,13 @@
 
 #if !defined(HAS_STRPTIME)
 # if !defined(_MSC_VER) && !defined(__MINGW32__) && !defined(__VXWORKS__)
-#  define HAS_STRPTIME 1  // assume everyone has strptime() except windows
-                          // and VxWorks
+#  define HAS_STRPTIME 1  // Assume everyone else has strptime().
 # endif
 #endif
 
 #if defined(HAS_STRPTIME) && HAS_STRPTIME
 # if !defined(_XOPEN_SOURCE) && !defined(__OpenBSD__)
-#  define _XOPEN_SOURCE  // Definedness suffices for strptime.
+#  define _XOPEN_SOURCE  // Definedness suffices for strptime().
 # endif
 #endif
 

--- a/src/time_zone_if.cc
+++ b/src/time_zone_if.cc
@@ -18,21 +18,21 @@
 
 namespace cctz {
 
-std::unique_ptr<TimeZoneIf> TimeZoneIf::UTC() { return TimeZoneInfo::UTC(); }
+std::unique_ptr<TimeZoneIf> TimeZoneIf::UTC() {
+  return TimeZoneInfo::UTC();
+}
 
-std::unique_ptr<TimeZoneIf> TimeZoneIf::Load(const std::string& name) {
+std::unique_ptr<TimeZoneIf> TimeZoneIf::Make(const std::string& name) {
   // Support "libc:localtime" and "libc:*" to access the legacy
   // localtime and UTC support respectively from the C library.
   // NOTE: The "libc:*" zones are internal, test-only interfaces, and
   // are subject to change/removal without notice. Do not use them.
   if (name.compare(0, 5, "libc:") == 0) {
-    return std::unique_ptr<TimeZoneIf>(new TimeZoneLibC(name.substr(5)));
+    return TimeZoneLibC::Make(name.substr(5));
   }
 
-  // Otherwise use the "zoneinfo" implementation by default.
-  std::unique_ptr<TimeZoneInfo> tz(new TimeZoneInfo);
-  if (!tz->Load(name)) tz.reset();
-  return std::unique_ptr<TimeZoneIf>(tz.release());
+  // Otherwise use the "zoneinfo" implementation.
+  return TimeZoneInfo::Make(name);
 }
 
 // Defined out-of-line to avoid emitting a weak vtable in all TUs.

--- a/src/time_zone_if.h
+++ b/src/time_zone_if.h
@@ -30,8 +30,8 @@ namespace cctz {
 class TimeZoneIf {
  public:
   // Factory functions for TimeZoneIf implementations.
-  static std::unique_ptr<TimeZoneIf> UTC();
-  static std::unique_ptr<TimeZoneIf> Load(const std::string& name);
+  static std::unique_ptr<TimeZoneIf> UTC();  // never fails
+  static std::unique_ptr<TimeZoneIf> Make(const std::string& name);
 
   virtual ~TimeZoneIf();
 
@@ -49,7 +49,9 @@ class TimeZoneIf {
   virtual std::string Description() const = 0;
 
  protected:
-  TimeZoneIf() {}
+  TimeZoneIf() = default;
+  TimeZoneIf(const TimeZoneIf&) = delete;
+  TimeZoneIf& operator=(const TimeZoneIf&) = delete;
 };
 
 // Convert between time_point<seconds> and a count of seconds since the

--- a/src/time_zone_impl.cc
+++ b/src/time_zone_impl.cc
@@ -97,13 +97,13 @@ void time_zone::Impl::ClearTimeZoneMapTestOnly() {
   }
 }
 
-time_zone::Impl::Impl(const std::string& name)
-    : name_(name), zone_(TimeZoneIf::Load(name_)) {}
-
 time_zone::Impl::Impl() : name_("UTC"), zone_(TimeZoneIf::UTC()) {}
 
+time_zone::Impl::Impl(const std::string& name)
+    : name_(name), zone_(TimeZoneIf::Make(name_)) {}
+
 const time_zone::Impl* time_zone::Impl::UTCImpl() {
-  static const Impl* utc_impl = new Impl;  // never fails
+  static const Impl* utc_impl = new Impl;
   return utc_impl;
 }
 

--- a/src/time_zone_impl.h
+++ b/src/time_zone_impl.h
@@ -76,6 +76,9 @@ class time_zone::Impl {
  private:
   Impl();
   explicit Impl(const std::string& name);
+  Impl(const Impl&) = delete;
+  Impl& operator=(const Impl&) = delete;
+
   static const Impl* UTCImpl();
 
   const std::string name_;

--- a/src/time_zone_info.h
+++ b/src/time_zone_info.h
@@ -61,14 +61,9 @@ struct TransitionType {
 // A time zone backed by the IANA Time Zone Database (zoneinfo).
 class TimeZoneInfo : public TimeZoneIf {
  public:
-  TimeZoneInfo() = default;
-  TimeZoneInfo(const TimeZoneInfo&) = delete;
-  TimeZoneInfo& operator=(const TimeZoneInfo&) = delete;
-
-  static std::unique_ptr<TimeZoneInfo> UTC();
-
-  // Loads the zoneinfo for the given name, returning true if successful.
-  bool Load(const std::string& name);
+  // Factories.
+  static std::unique_ptr<TimeZoneInfo> UTC();  // never fails
+  static std::unique_ptr<TimeZoneInfo> Make(const std::string& name);
 
   // TimeZoneIf implementations.
   time_zone::absolute_lookup BreakTime(
@@ -83,17 +78,9 @@ class TimeZoneInfo : public TimeZoneIf {
   std::string Description() const override;
 
  private:
-  struct Header {  // counts of:
-    std::size_t timecnt;     // transition times
-    std::size_t typecnt;     // transition types
-    std::size_t charcnt;     // zone abbreviation characters
-    std::size_t leapcnt;     // leap seconds (we expect none)
-    std::size_t ttisstdcnt;  // UTC/local indicators (unused)
-    std::size_t ttisutcnt;   // standard/wall indicators (unused)
-
-    bool Build(const tzhead& tzh);
-    std::size_t DataLength(std::size_t time_len) const;
-  };
+  TimeZoneInfo() = default;
+  TimeZoneInfo(const TimeZoneInfo&) = delete;
+  TimeZoneInfo& operator=(const TimeZoneInfo&) = delete;
 
   bool GetTransitionType(std::int_fast32_t utc_offset, bool is_dst,
                          const std::string& abbr, std::uint_least8_t* index);
@@ -102,6 +89,7 @@ class TimeZoneInfo : public TimeZoneIf {
   bool ExtendTransitions();
 
   bool ResetToBuiltinUTC(const seconds& offset);
+  bool Load(const std::string& name);
   bool Load(ZoneInfoSource* zip);
 
   // Helpers for BreakTime() and MakeTime().

--- a/src/time_zone_libc.cc
+++ b/src/time_zone_libc.cc
@@ -58,7 +58,7 @@ auto tm_zone(const std::tm& tm) -> decltype(tzname[0]) {
 }
 #elif defined(__native_client__) || defined(__myriad2__) || \
     defined(__EMSCRIPTEN__)
-// Uses the globals: 'timezone' and 'tzname'.
+// Uses the globals: '_timezone' and 'tzname'.
 auto tm_gmtoff(const std::tm& tm) -> decltype(_timezone + 0) {
   const bool is_dst = tm.tm_isdst > 0;
   return _timezone + (is_dst ? 60 * 60 : 0);
@@ -191,8 +191,9 @@ std::time_t find_trans(std::time_t lo, std::time_t hi, tm_gmtoff_t offset) {
 
 }  // namespace
 
-TimeZoneLibC::TimeZoneLibC(const std::string& name)
-    : local_(name == "localtime") {}
+std::unique_ptr<TimeZoneLibC> TimeZoneLibC::Make(const std::string& name) {
+  return std::unique_ptr<TimeZoneLibC>(new TimeZoneLibC(name));
+}
 
 time_zone::absolute_lookup TimeZoneLibC::BreakTime(
     const time_point<seconds>& tp) const {
@@ -321,5 +322,8 @@ std::string TimeZoneLibC::Version() const {
 std::string TimeZoneLibC::Description() const {
   return local_ ? "localtime" : "UTC";
 }
+
+TimeZoneLibC::TimeZoneLibC(const std::string& name)
+    : local_(name == "localtime") {}
 
 }  // namespace cctz

--- a/src/time_zone_libc.h
+++ b/src/time_zone_libc.h
@@ -23,10 +23,10 @@ namespace cctz {
 
 // A time zone backed by gmtime_r(3), localtime_r(3), and mktime(3),
 // and which therefore only supports UTC and the local time zone.
-// TODO: Add support for fixed offsets from UTC.
 class TimeZoneLibC : public TimeZoneIf {
  public:
-  explicit TimeZoneLibC(const std::string& name);
+  // Factory.
+  static std::unique_ptr<TimeZoneLibC> Make(const std::string& name);
 
   // TimeZoneIf implementations.
   time_zone::absolute_lookup BreakTime(
@@ -41,6 +41,10 @@ class TimeZoneLibC : public TimeZoneIf {
   std::string Description() const override;
 
  private:
+  explicit TimeZoneLibC(const std::string& name);
+  TimeZoneLibC(const TimeZoneLibC&) = delete;
+  TimeZoneLibC& operator=(const TimeZoneLibC&) = delete;
+
   const bool local_;  // localtime or UTC
 };
 

--- a/src/time_zone_lookup_test.cc
+++ b/src/time_zone_lookup_test.cc
@@ -730,6 +730,10 @@ TEST(TimeZone, UTC) {
   time_zone loaded_utc0;
   EXPECT_TRUE(load_time_zone("UTC0", &loaded_utc0));
   EXPECT_EQ(loaded_utc0, utc);
+
+  time_zone loaded_bad;
+  EXPECT_FALSE(load_time_zone("Invalid/TimeZone", &loaded_bad));
+  EXPECT_EQ(loaded_bad, utc);
 }
 
 TEST(TimeZone, NamedTimeZones) {


### PR DESCRIPTION
Follow the direction of #256, which added factory functions for UTC, and add them for named time zones too.  This tightens up the `TimeZoneInfo` and `TimeZoneLibC` interfaces a little, most notably by allowing `TimeZoneInfo::Load(const std::string&)` to become private.  Re-order the implementation as a result (which forms the majority of the diff, sorry).

Also, add a new test to check that a `load_time_zone()` failure results in a `time_zone` that compares equal to `utc_time_zone()`.

Finally, cleanup a couple of unrelated comments.