### PR TITLE
Revert "build: fix cross-platform android builds on OS X (#237)"

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -52,10 +52,11 @@ cc_library(
         "include/cctz/zone_info_source.h",
     ],
     includes = ["include"],
-    # OS X and iOS no longer use `linkopts = ["-framework CoreFoundation"]`
-    # as (1) bazel adds it automatically, and (2) it caused problems when
-    # cross-compiling for Android.
-    # See https://github.com/abseil/abseil-cpp/issues/326 for details.
+    linkopts = select({
+        "@platforms//os:osx": ["-Wl,-framework,CoreFoundation"],
+        "@platforms//os:ios": ["-Wl,-framework,CoreFoundation"],
+        "//conditions:default": [],
+    }),
     visibility = ["//visibility:public"],
     deps = [":civil_time"],
 )


### PR DESCRIPTION
This breaks toolchains that don't add the implicit Foundation linkopt. I can no longer reproduce this building envoy for Android so I'm not sure if we mis-diagnosed the issue, or if it was fixed another way.

https://github.com/google/cctz/pull/237

This reverts commit 5417654582642359a597b273bacaaedcc99f758f.