### PR TITLE
Extend transitions for a full 400 years

### DIFF
--- a/src/time_zone_info.cc
+++ b/src/time_zone_info.cc
@@ -363,7 +363,7 @@ bool TimeZoneInfo::ExtendTransitions() {
       if (last_time < ta->unix_time) transitions_.push_back(*ta);
       transitions_.push_back(*tb);
     }
-    if (last_year_ == limit) break;
+    if (last_year_ > limit) break;
     jan1_time += kSecsPerYear[leap_year];
     jan1_weekday = (jan1_weekday + kDaysPerYear[leap_year]) % 7;
     leap_year = !leap_year && IsLeap(last_year_ + 1);

--- a/src/time_zone_lookup_test.cc
+++ b/src/time_zone_lookup_test.cc
@@ -132,6 +132,7 @@ const char* const kTimeZoneNames[] = {
   "America/Cayman",
   "America/Chicago",
   "America/Chihuahua",
+  "America/Ciudad_Juarez",
   "America/Coral_Harbour",
   "America/Cordoba",
   "America/Costa_Rica",


### PR DESCRIPTION
2022g introduced a new zone, America/Ciudad_Juarez, whose "-b slim" form ends in a year (2022) with three transitions, and which therefore cannot fully match the POSIX TZ string used to handle instants after the last transition.

Previously we assumed that the last-year's transitions would match those generated by the POSIX string.  In this case that meant we claimed there was an extra transition in any future year equivalent to (2022 mod 400).

So, extend the transitions using the POSIX string for a full 400 years, instead of 399.