### PR TITLE
Extend transitions for 401 years

### DIFF
--- a/src/time_zone_info.cc
+++ b/src/time_zone_info.cc
@@ -334,11 +334,13 @@ bool TimeZoneInfo::ExtendTransitions() {
     return EquivTransitions(transitions_.back().type_index, dst_ti);
   }
 
-  // Extend the transitions for an additional 400 years using the
-  // future specification. Years beyond those can be handled by
-  // mapping back to a cycle-equivalent year within that range.
-  // We may need two additional transitions for the current year.
-  transitions_.reserve(transitions_.size() + 400 * 2 + 2);
+  // Extend the transitions for an additional 401 years using the future
+  // specification. Years beyond those can be handled by mapping back to
+  // a cycle-equivalent year within that range. Note that we need 401
+  // (well, at least the first transition in the 401st year) so that the
+  // end of the 400th year is mapped back to an extended year.) And first
+  // we may also need two additional transitions for the current year.
+  transitions_.reserve(transitions_.size() + 2 + 401 * 2);
   extended_ = true;
 
   const Transition& last(transitions_.back());
@@ -352,7 +354,7 @@ bool TimeZoneInfo::ExtendTransitions() {
 
   Transition dst = {0, dst_ti, civil_second(), civil_second()};
   Transition std = {0, std_ti, civil_second(), civil_second()};
-  for (const year_t limit = last_year_ + 400;; ++last_year_) {
+  for (const year_t limit = last_year_ + 401;; ++last_year_) {
     auto dst_trans_off = TransOffset(leap_year, jan1_weekday, posix.dst_start);
     auto std_trans_off = TransOffset(leap_year, jan1_weekday, posix.dst_end);
     dst.unix_time = jan1_time + dst_trans_off - posix.std_offset;

--- a/src/time_zone_info.cc
+++ b/src/time_zone_info.cc
@@ -338,7 +338,7 @@ bool TimeZoneInfo::ExtendTransitions() {
   // specification. Years beyond those can be handled by mapping back to
   // a cycle-equivalent year within that range. Note that we need 401
   // (well, at least the first transition in the 401st year) so that the
-  // end of the 400th year is mapped back to an extended year.) And first
+  // end of the 400th year is mapped back to an extended year. And first
   // we may also need two additional transitions for the current year.
   transitions_.reserve(transitions_.size() + 2 + 401 * 2);
   extended_ = true;

--- a/src/time_zone_lookup_test.cc
+++ b/src/time_zone_lookup_test.cc
@@ -132,6 +132,7 @@ const char* const kTimeZoneNames[] = {
   "America/Cayman",
   "America/Chicago",
   "America/Chihuahua",
+  "America/Ciudad_Juarez",
   "America/Coral_Harbour",
   "America/Cordoba",
   "America/Costa_Rica",


### PR DESCRIPTION
2022g introduced a new zone, America/Ciudad_Juarez, whose "-b slim" form ends in 2022, but with transitions that do not match those that would be generated by the POSIX TZ string used to handle instants in future years.

If we extend the transitions for only 400 years, instants beyond the last generated transition in years equivalent to (2022 mod 400), will be mapped back to 2022, where they could therefore be given the wrong treatment.

So, extend the transitions using the POSIX string for 401 years instead. This means we will always map back to a generated year (in this case, 2023 to 2422).