### PR TITLE
MSVC version greater 17.7.1 would give errors for civil_time_detail.h…

### DIFF
--- a/include/cctz/civil_time_detail.h
+++ b/include/cctz/civil_time_detail.h
@@ -367,11 +367,11 @@ class civil_time {
       : civil_time(ct.f_) {}
 
   // Factories for the maximum/minimum representable civil_time.
-  static CONSTEXPR_F auto (max)()->civil_time {
+  static CONSTEXPR_F auto (max)() -> civil_time {
     const auto max_year = (std::numeric_limits<std::int_least64_t>::max)();
     return civil_time(max_year, 12, 31, 23, 59, 59);
   }
-  static CONSTEXPR_F auto (min)()->civil_time {
+  static CONSTEXPR_F auto (min)() -> civil_time {
     const auto min_year = (std::numeric_limits<std::int_least64_t>::min)();
     return civil_time(min_year, 1, 1, 0, 0, 0);
   }

--- a/include/cctz/civil_time_detail.h
+++ b/include/cctz/civil_time_detail.h
@@ -367,11 +367,11 @@ class civil_time {
       : civil_time(ct.f_) {}
 
   // Factories for the maximum/minimum representable civil_time.
-  static CONSTEXPR_F civil_time (max)() {
+  static CONSTEXPR_F auto (max)()->civil_time {
     const auto max_year = (std::numeric_limits<std::int_least64_t>::max)();
     return civil_time(max_year, 12, 31, 23, 59, 59);
   }
-  static CONSTEXPR_F civil_time (min)() {
+  static CONSTEXPR_F auto (min)()->civil_time {
     const auto min_year = (std::numeric_limits<std::int_least64_t>::min)();
     return civil_time(min_year, 1, 1, 0, 0, 0);
   }


### PR DESCRIPTION
Note - this PR is transferred from Abseil  issue https://github.com/abseil/abseil-cpp/pull/1527#issuecomment-1703949292
----

MSVC version greater 17.7.1 would give C2059 errors for civil_time_detail.h Line 370 and Line 374. The compiler cannot tell that (max) is a member function, NOT a macro. A trailing return type would fix this.

Otherwise, MSVC 17.7.1 or newer would have the following errors (that previous MSVC versions are good):

C:\develop\VcPkg\installed\x64-windows\include\absl/time/internal/cctz/include/cctz/civil_time_detail.h(400): error C2059: syntax error: ''symbol''
C:\develop\VcPkg\installed\x64-windows\include\absl/time/internal/cctz/include/cctz/civil_time_detail.h(468): note: see reference to class template instantiation 'absl::lts_20210324::time_internal::cctz::detail::civil_time' being compiled
C:\develop\VcPkg\installed\x64-windows\include\absl/time/internal/cctz/include/cctz/civil_time_detail.h(400): error C2091: function returns function
C:\develop\VcPkg\installed\x64-windows\include\absl/time/internal/cctz/include/cctz/civil_time_detail.h(400): error C2574: '(__cdecl *absl::lts_20210324::time_internal::cctz::detail::civil_time::civil_time(void))(void)': cannot be declared static
C:\develop\VcPkg\installed\x64-windows\include\absl/time/internal/cctz/include/cctz/civil_time_detail.h(404): error C2059: syntax error: ''symbol''