### PR TITLE
Bazel: Support header_modules, layering_check and parse_headers

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -12,6 +12,14 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+package(
+    features = [
+        "header_modules",
+        "layering_check",
+        "parse_headers",
+    ],
+)
+
 licenses(["notice"])
 
 ### libraries
@@ -74,6 +82,7 @@ cc_test(
     srcs = ["src/civil_time_test.cc"],
     deps = [
         ":civil_time",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -85,6 +94,7 @@ cc_test(
     deps = [
         ":civil_time",
         ":time_zone",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -96,6 +106,7 @@ cc_test(
     deps = [
         ":civil_time",
         ":time_zone",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )


### PR DESCRIPTION
The layering_check feature ensures that rules that include a header explicitly depend on a rule that exports that header. Compiler support is required, and currently only Clang 16+ supports diagnoses layering_check failures.

The parse_headers feature ensures headers are self-contained by compiling them with -fsyntax-only on supported compilers.

The header_modules feature is Bazel support for modules and is already enabled when CCTZ is included in Abseil. This just reduces the BUILD diff.

Tested with Clang 17