### PR TITLE
[Android] Remove unnecessary __system_property_get definition

### DIFF
--- a/src/time_zone_lookup.cc
+++ b/src/time_zone_lookup.cc
@@ -16,9 +16,6 @@
 
 #if defined(__ANDROID__)
 #include <sys/system_properties.h>
-#if defined(__ANDROID_API__) && __ANDROID_API__ >= 21
-#include <dlfcn.h>
-#endif
 #endif
 
 #if defined(__APPLE__)
@@ -61,32 +58,6 @@
 namespace cctz {
 
 namespace {
-#if defined(__ANDROID__) && defined(__ANDROID_API__) && __ANDROID_API__ >= 21
-// Android 'L' removes __system_property_get() from the NDK, however
-// it is still a hidden symbol in libc so we use dlsym() to access it.
-// See Chromium's base/sys_info_android.cc for a similar example.
-
-using property_get_func = int (*)(const char*, char*);
-
-property_get_func LoadSystemPropertyGet() {
-  int flag = RTLD_LAZY | RTLD_GLOBAL;
-#if defined(RTLD_NOLOAD)
-  flag |= RTLD_NOLOAD;  // libc.so should already be resident
-#endif
-  if (void* handle = dlopen("libc.so", flag)) {
-    void* sym = dlsym(handle, "__system_property_get");
-    dlclose(handle);
-    return reinterpret_cast<property_get_func>(sym);
-  }
-  return nullptr;
-}
-
-int __system_property_get(const char* name, char* value) {
-  static property_get_func system_property_get = LoadSystemPropertyGet();
-  return system_property_get ? system_property_get(name, value) : -1;
-}
-#endif
-
 #if defined(USE_WIN32_LOCAL_TIME_ZONE)
 // Calls the WinRT Calendar.GetTimeZone method to obtain the IANA ID of the
 // local time zone. Returns an empty vector in case of an error.


### PR DESCRIPTION
See: https://github.com/chromium/chromium/commit/03d8ffbb86e87ee36e2aa6dc8e650dd0a2ba1fe2

The example cited in the code comment from chromium has been removed. It turns out this was never necessary and it is not clear why it was added to chromium in the first place (see the commit message from the commit linked above).

Although this definition of __system_property_get does not cause any issues because it is defined in an anonymous namespace, it is unnecessary and misleading, and we should remove it in favor of the one directly available from libc.so.