### PR TITLE
Do not redefine _CRT_SECURE_NO_WARNINGS if it's defined

### DIFF
--- a/src/time_zone_libc.cc
+++ b/src/time_zone_libc.cc
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-#if defined(_WIN32) || defined(_WIN64)
+#if !defined(_CRT_SECURE_NO_WARNINGS) && defined(_WIN32)
 #define _CRT_SECURE_NO_WARNINGS 1
 #endif
 


### PR DESCRIPTION
Old test checked `defined(_WIN32) || defined(_WIN64)`, which is redundant. `_WIN32` is always defined for `_WIN64` builds as well (https://learn.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=msvc-170&redirectedfrom=MSDN):
```
_WIN32 Defined as 1 when the compilation target is 32-bit ARM, 64-bit ARM, x86, or x64. Otherwise, undefined
```

 `_CRT_SECURE_NO_WARNINGS` could be defined externally, this code would produce this warning:
```
1>D:\abseil-cpp\absl\time\internal\cctz\src\time_zone_libc.cc(16,9): warning C4005: '_CRT_SECURE_NO_WARNINGS': macro redefinition
```
The PR addresses the issue.