### PR TITLE
Simplify next_weekday and prev_weekday calculus

### DIFF
--- a/include/cctz/civil_time_detail.h
+++ b/include/cctz/civil_time_detail.h
@@ -527,43 +527,27 @@ CONSTEXPR_F weekday get_weekday(const civil_second& cs) noexcept {
 ////////////////////////////////////////////////////////////////////////
 
 CONSTEXPR_F civil_day next_weekday(civil_day cd, weekday wd) noexcept {
-  CONSTEXPR_D weekday k_weekdays_forw[14] = {
-      weekday::monday,    weekday::tuesday,  weekday::wednesday,
-      weekday::thursday,  weekday::friday,   weekday::saturday,
-      weekday::sunday,    weekday::monday,   weekday::tuesday,
-      weekday::wednesday, weekday::thursday, weekday::friday,
-      weekday::saturday,  weekday::sunday,
-  };
-  weekday base = get_weekday(cd);
-  for (int i = 0;; ++i) {
-    if (base == k_weekdays_forw[i]) {
-      for (int j = i + 1;; ++j) {
-        if (wd == k_weekdays_forw[j]) {
-          return cd + (j - i);
-        }
-      }
-    }
+  std::int_fast8_t wd_old = static_cast<std::int_fast8_t>(get_weekday(cd));
+  std::int_fast8_t wd_new = static_cast<std::int_fast8_t>(wd);
+
+  std::int_fast8_t weekday_diff = wd_new - wd_old;
+  if (weekday_diff <= 0) {
+    weekday_diff += 7;
   }
+
+  return cd + weekday_diff;
 }
 
 CONSTEXPR_F civil_day prev_weekday(civil_day cd, weekday wd) noexcept {
-  CONSTEXPR_D weekday k_weekdays_back[14] = {
-      weekday::sunday,   weekday::saturday,  weekday::friday,
-      weekday::thursday, weekday::wednesday, weekday::tuesday,
-      weekday::monday,   weekday::sunday,    weekday::saturday,
-      weekday::friday,   weekday::thursday,  weekday::wednesday,
-      weekday::tuesday,  weekday::monday,
-  };
-  weekday base = get_weekday(cd);
-  for (int i = 0;; ++i) {
-    if (base == k_weekdays_back[i]) {
-      for (int j = i + 1;; ++j) {
-        if (wd == k_weekdays_back[j]) {
-          return cd - (j - i);
-        }
-      }
-    }
+  std::int_fast8_t wd_old = static_cast<std::int_fast8_t>(get_weekday(cd));
+  std::int_fast8_t wd_new = static_cast<std::int_fast8_t>(wd);
+
+  std::int_fast8_t weekday_diff = wd_old - wd_new;
+  if (weekday_diff <= 0) {
+    weekday_diff += 7;
   }
+
+  return cd - weekday_diff;
 }
 
 CONSTEXPR_F int get_yearday(const civil_second& cs) noexcept {

--- a/src/civil_time_test.cc
+++ b/src/civil_time_test.cc
@@ -312,6 +312,8 @@ TEST(CivilTime, NextWeekDay) {
   static_assert(next.year() == 2016, "NextWeekDay.year");
   static_assert(next.month() == 2, "NextWeekDay.month");
   static_assert(next.day() == 4, "NextWeekDay.day");
+
+  static_assert(static_cast<int>(weekday::monday) == 0, "Monday is not 0");
 }
 
 TEST(CivilTime, PrevWeekDay) {
@@ -320,6 +322,8 @@ TEST(CivilTime, PrevWeekDay) {
   static_assert(prev.year() == 2016, "PrevWeekDay.year");
   static_assert(prev.month() == 1, "PrevWeekDay.month");
   static_assert(prev.day() == 21, "PrevWeekDay.day");
+
+  static_assert(static_cast<int>(weekday::monday) == 0, "Monday is not 0");
 }
 
 TEST(CivilTime, YearDay) {


### PR DESCRIPTION
It seems that calculating next and previous weekday is over complicated. We can make it simpler and faster. On my test on x86-64 I get following results

```
Run on (14 X 2496.01 MHz CPU s)
CPU Caches:
  L1 Data 48 KiB (x7)
  L1 Instruction 32 KiB (x7)
  L2 Unified 1280 KiB (x7)
  L3 Unified 24576 KiB (x1)
Load Average: 1.68, 0.75, 0.72
---------------------------------------------------------------------------
Benchmark                                 Time             CPU   Iterations
---------------------------------------------------------------------------
BM_NextWeekday                         5.63 ns         5.63 ns    123274543
BM_NextWeekday_new                     3.85 ns         3.85 ns    182678076
BM_PrevWeekday                         4.70 ns         4.70 ns    146452964
BM_PrevWeekday_new                     3.24 ns         3.24 ns    221581381
```

This is also safer on situations where this function gets weekday as not enum. Yeah that is unlikely but one more plus for this.

Previously there where suggestion [1] for this as

```c++
  auto n = static_cast<std::int_fast8_t>(get_weekday(cd));
  auto x = static_cast<std::int_fast8_t>(wd);
  return cd + (1 + (x + 6 - n) % 7);
```

But that imo is not so easy to understand than this algorithm. Also it did not do so good performance wise.

On test side I added static_assert just in case someone choose to change order of weekday. Higly unlikely but I like to be safe side.

[1]: https://github.com/google/cctz/pull/105#discussion_r279593675