### PR TITLE
RFC: Add number_to_weekday and weekday_to_number

### DIFF
--- a/include/cctz/civil_time.h
+++ b/include/cctz/civil_time.h
@@ -311,6 +311,34 @@ using detail::get_weekday;
 using detail::next_weekday;
 using detail::prev_weekday;
 
+// An enum class with members monday_zero, monday_one, sunday_zero, sunday_one.
+// These enum values can be used to specify the start of the week for the
+// weekday_to_number and number_to_weekday functions.
+//
+// monday_zero: monday == 0, ..., sunday == 6
+// monday_one:  monday == 1, ..., sunday == 7
+// sunday_zero: sunday == 0, ..., saturday == 6
+// sunday_one:  sunday == 1, ..., saturday == 7
+//
+using detail::weekstart;
+
+// Returns the number of weekday with given start of week.
+//
+//   civil_day a(2015, 8, 13); // thursday
+//   int wd = weekday_to_number(get_weekday(a), monday_zero);  // wd == 4
+//
+using detail::weekday_to_number;
+
+// Returns the weekday for the given number with given start of week.
+//   
+//   std::string err;  // Optional error message
+//   weekday wd = number_to_weekday(input, monday_zero, &err);
+//   if (!err.empty()) {
+//     // Handle error
+//   }
+//
+using detail::number_to_weekday;
+
 // Returns the day-of-year for the given civil-time value.
 //
 //   civil_day a(2015, 1, 1);

--- a/include/cctz/civil_time_detail.h
+++ b/include/cctz/civil_time_detail.h
@@ -18,6 +18,7 @@
 #include <cstdint>
 #include <limits>
 #include <ostream>
+#include <string>
 #include <type_traits>
 
 // Disable constexpr support unless we are in C++14 mode.
@@ -565,6 +566,198 @@ CONSTEXPR_F civil_day prev_weekday(civil_day cd, weekday wd) noexcept {
     }
   }
 }
+
+////////////////////////////////////////////////////////////////////////
+
+enum class weekstart
+{
+  monday_zero,
+  monday_one,
+  sunday_zero,
+  sunday_one,
+};
+
+CONSTEXPR_F int weekday_to_number(weekday wd, weekstart ws) noexcept {
+  switch(ws) {
+    case weekstart::monday_zero:
+      switch (wd) {
+        case weekday::monday:
+          return 0;
+        case weekday::tuesday:
+          return 1;
+        case weekday::wednesday:
+          return 2;
+        case weekday::thursday:
+          return 3;
+        case weekday::friday:
+          return 4;
+        case weekday::saturday:
+          return 5;
+        case weekday::sunday:
+          return 6;
+      }
+      break;
+    case weekstart::monday_one:
+      switch (wd) {
+        case weekday::monday:
+          return 1;
+        case weekday::tuesday:
+          return 2;
+        case weekday::wednesday:
+          return 3;
+        case weekday::thursday:
+          return 4;
+        case weekday::friday:
+          return 5;
+        case weekday::saturday:
+          return 6;
+        case weekday::sunday:
+          return 7;
+      }
+      break;
+    case weekstart::sunday_zero:
+      switch (wd) {
+        case weekday::sunday:
+          return 0;
+        case weekday::monday:
+          return 1;
+        case weekday::tuesday:
+          return 2;
+        case weekday::wednesday:
+          return 3;
+        case weekday::thursday:
+          return 4;
+        case weekday::friday:
+          return 5;
+        case weekday::saturday:
+          return 6;
+      }
+      break;
+    case weekstart::sunday_one:
+      switch (wd) {
+        case weekday::sunday:
+          return 1;
+        case weekday::monday:
+          return 2;
+        case weekday::tuesday:
+          return 3;
+        case weekday::wednesday:
+          return 4;
+        case weekday::thursday:
+          return 5;
+        case weekday::friday:
+          return 6;
+        case weekday::saturday:
+          return 7;
+      }
+      break;
+  }
+
+  // Undefined behavior.
+  return 0;
+}
+
+CONSTEXPR_F weekday number_to_weekday(int wd, weekstart ws, std::string* err = nullptr) noexcept {
+  const char invalid_weekday_err[] = "Invalid weekday number for weekday";
+
+  switch(ws) {
+    case weekstart::monday_zero:
+      switch (wd) {
+        case 0:
+          return weekday::monday;
+        case 1:
+          return weekday::tuesday;
+        case 2:
+          return weekday::wednesday;
+        case 3:
+          return weekday::thursday;
+        case 4:
+          return weekday::friday;
+        case 5:
+          return weekday::saturday;
+        case 6:
+          return weekday::sunday;
+        default:
+          if (err) {
+            *err = invalid_weekday_err;
+          }
+          return weekday::monday;
+      }
+      break;
+    case weekstart::monday_one:
+      switch (wd) {
+        case 1:
+          return weekday::monday;
+        case 2:
+          return weekday::tuesday;
+        case 3:
+          return weekday::wednesday;
+        case 4:
+          return weekday::thursday;
+        case 5:
+          return weekday::friday;
+        case 6:
+          return weekday::saturday;
+        case 7:
+          return weekday::sunday;
+        default:
+          if (err) {
+            *err = invalid_weekday_err;
+          }
+          return weekday::monday;
+      }
+      break;
+    case weekstart::sunday_zero:
+      switch (wd) {
+        case 0:
+          return weekday::sunday;
+        case 1:
+          return weekday::monday;
+        case 2:
+          return weekday::tuesday;
+        case 3:
+          return weekday::wednesday;
+        case 4:
+          return weekday::thursday;
+        case 5:
+          return weekday::friday;
+        case 6:
+          return weekday::saturday;
+        default:
+          if (err) {
+            *err = invalid_weekday_err;
+          }
+          return weekday::sunday;
+      }
+    case weekstart::sunday_one:
+      switch (wd) {
+        case 1:
+          return weekday::sunday;
+        case 2:
+          return weekday::monday;
+        case 3:
+          return weekday::tuesday;
+        case 4:
+          return weekday::wednesday;
+        case 5:
+          return weekday::thursday;
+        case 6:
+          return weekday::friday;
+        case 7:
+          return weekday::saturday;
+        default:
+          if (err) {
+            *err = invalid_weekday_err;
+          }
+          return weekday::sunday;
+      }
+  }
+
+  // Undefined behavior.
+  return weekday::monday;
+}
+
+////////////////////////////////////////////////////////////////////////
 
 CONSTEXPR_F int get_yearday(const civil_second& cs) noexcept {
   CONSTEXPR_D int k_month_offsets[1 + 12] = {

--- a/src/time_zone_info.cc
+++ b/src/time_zone_info.cc
@@ -81,27 +81,6 @@ const std::int_least32_t kSecsPerYear[2] = {
   366 * kSecsPerDay,
 };
 
-// Convert a cctz::weekday to a POSIX TZ weekday number (0==Sun, ..., 6=Sat).
-inline int ToPosixWeekday(weekday wd) {
-  switch (wd) {
-    case weekday::sunday:
-      return 0;
-    case weekday::monday:
-      return 1;
-    case weekday::tuesday:
-      return 2;
-    case weekday::wednesday:
-      return 3;
-    case weekday::thursday:
-      return 4;
-    case weekday::friday:
-      return 5;
-    case weekday::saturday:
-      return 6;
-  }
-  return 0; /*NOTREACHED*/
-}
-
 // Single-byte, unsigned numeric values are encoded directly.
 inline std::uint_fast8_t Decode8(const char* cp) {
   return static_cast<std::uint_fast8_t>(*cp) & 0xff;
@@ -350,7 +329,7 @@ bool TimeZoneInfo::ExtendTransitions() {
   bool leap_year = IsLeap(last_year_);
   const civil_second jan1(last_year_);
   std::int_fast64_t jan1_time = jan1 - civil_second();
-  int jan1_weekday = ToPosixWeekday(get_weekday(jan1));
+  int jan1_weekday = weekday_to_number(get_weekday(jan1), weekstart::sunday_zero);
 
   Transition dst = {0, dst_ti, civil_second(), civil_second()};
   Transition std = {0, std_ti, civil_second(), civil_second()};


### PR DESCRIPTION
Currently this is just suggestion. Example no unittests yet and some details
could be changed.

We have discussion in this PR [1] that weekday should not be casted. I check
our company codebase and we did cast weekday 9 places (oops). We definitely
need those cast as we are example converting them for external APIs. So for
this reason I implemented internally very similar functions as in this PR. I would
like to know if this is something could fit for cctz. Right place could also be
Abseil so please let me know what you think.

[1]: https://github.com/google/cctz/pull/290

