### PR TITLE
[cmake] Require CMake 3.16

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,6 @@
-cmake_minimum_required(VERSION 2.8.12)
-
-if (POLICY CMP0025)
-  cmake_policy(SET CMP0025 NEW)
-endif()
+# https://github.com/google/oss-policies-info/blob/main/foundational-cxx-support-matrix.md
+# As of 2024-07-01, CMake 3.16 is the minimum supported version.
+cmake_minimum_required(VERSION 3.16)
 
 project(cctz)
 
@@ -51,20 +49,12 @@ if (BUILD_TESTING)
   )
 endif()
 
-# Starting from CMake >= 3.1, if a specific standard is required,
+# If a specific standard is required,
 # it can be set from the command line with:
-#     cmake -DCMAKE_CXX_STANDARD=[11|14|17]
+#     cmake -DCMAKE_CXX_STANDARD=[11|14|17|20|23]
 function(cctz_target_set_cxx_standard target)
   set(cxx_standard 11)
-  if (CMAKE_VERSION VERSION_LESS "3.1")
-    if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
-      target_compile_options(${target} PRIVATE -std=c++${cxx_standard})
-    endif()
-  elseif (CMAKE_VERSION VERSION_LESS "3.8")
-    set_property(TARGET ${target} PROPERTY CXX_STANDARD ${cxx_standard})
-  else()
-    target_compile_features(${target} PUBLIC cxx_std_${cxx_standard})
-  endif()
+  target_compile_features(${target} PUBLIC cxx_std_${cxx_standard})
 endfunction()
 
 if(APPLE)
@@ -191,10 +181,6 @@ install(FILES cmake/${PROJECT_NAME}-config.cmake
   DESTINATION ${CMAKE_INSTALL_CONFIGDIR}
   )
 
-if (CMAKE_VERSION VERSION_LESS "3.8")
-  set(quiet_on_empty "")
-else()
-  set(quiet_on_empty QUIET_ON_EMPTY)
-endif()
+set(quiet_on_empty QUIET_ON_EMPTY)
 
 feature_summary(WHAT ALL FATAL_ON_MISSING_REQUIRED_PACKAGES ${quiet_on_empty})


### PR DESCRIPTION
Follow Google's OSS policy.
Remove other code specific for CMake < 3.16