### PR TITLE
[cmake] Find Benchmark quiet

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ${BUILD_SHARED_LIBS})
 
 if (BUILD_TESTING)
   if (BUILD_BENCHMARK)
-    find_package(benchmark)
+    find_package(benchmark QUIET)
     set_package_properties(benchmark PROPERTIES
       TYPE REQUIRED
       DESCRIPTION "a microbenchmark support library"


### PR DESCRIPTION
The output does not help identifiy the issue, the missing dependency is called out in the feature summary anyway.