### PR TITLE
Revert "Use reference in range-for with non trivial type"

### DIFF
--- a/src/time_zone_info.cc
+++ b/src/time_zone_info.cc
@@ -551,7 +551,7 @@ std::unique_ptr<ZoneInfoSource> FuchsiaZoneInfoSource::Open(
   const auto prefixes = name_absolute ? kEmptyPrefix : kTzdataPrefixes;
 
   // Fuchsia builds place zoneinfo files at "<prefix><format><name>".
-  for (const std::string& prefix : prefixes) {
+  for (const std::string prefix : prefixes) {
     std::string path = prefix;
     if (!prefix.empty()) path += "zoneinfo/tzif2/";  // format
     path.append(name, pos, std::string::npos);


### PR DESCRIPTION
/abseil-cpp/absl/time/internal/cctz/src/time_zone_info.cc:559:27: error: loop variable 'prefix' of type 'const std::string&' {aka 'const std::__cxx11::basic_string<char>&'} binds to a temporary constructed from type 'const char* const' [-Werror=range-loop-construct]
  559 |   for (const std::string& prefix : prefixes) {