### PR TITLE
Support for QNX 7.1

### DIFF
--- a/src/time_zone_format.cc
+++ b/src/time_zone_format.cc
@@ -20,7 +20,11 @@
 
 #if defined(HAS_STRPTIME) && HAS_STRPTIME
 # if !defined(_XOPEN_SOURCE) && !defined(__FreeBSD__) && !defined(__OpenBSD__)
-#  define _XOPEN_SOURCE 500  // Exposes definitions for SUSv2 (UNIX 98).
+#  if defined(__QNX__)
+#    define _XOPEN_SOURCE 600  // Exposes definitions for QNX 7.1.
+#  else
+#    define _XOPEN_SOURCE 500  // Exposes definitions for SUSv2 (UNIX 98).
+#  endif
 # endif
 #endif
 


### PR DESCRIPTION
Without specifying _XOPEN_SOURCE>=600, QNX 7.1 fails with:

```
/target/qnx7/usr/include/c++/v1/__threading_support: In function 'int std::__1::__libcpp_condvar_timedwait(std::__1::__libcpp_condvar_t*, std::__1::__libcpp_mutex_t*, timespec*)': /target/qnx7/usr/include/c++/v1/__threading_support:293:10: error: 'pthread_cond_timedwait' was not declared in this scope
   return pthread_cond_timedwait(__cv, __m, __ts);
          ^~~~~~~~~~~~~~~~~~~~~~
/target/qnx7/usr/include/c++/v1/__threading_support:293:10: note: suggested alternative: 'pthread_cond_wait'
   return pthread_cond_timedwait(__cv, __m, __ts);
          ^~~~~~~~~~~~~~~~~~~~~~
          pthread_cond_wait
```