### PR TITLE
[fuchsia] Updates the FIDL bindings in Fuchsia-specific code

### DIFF
--- a/src/time_zone_lookup.cc
+++ b/src/time_zone_lookup.cc
@@ -24,7 +24,7 @@
 #endif
 
 #if defined(__Fuchsia__)
-#include <fuchsia/intl/cpp/fidl.h>
+#include <fidl/fuchsia.intl/cpp/fidl.h>
 #include <lib/async-loop/cpp/loop.h>
 #include <lib/fdio/directory.h>
 #include <zircon/types.h>
@@ -218,32 +218,31 @@ time_zone local_time_zone() {
     // Note: We can't use the synchronous FIDL API here because it doesn't
     // allow timeouts; if the FIDL call failed, local_time_zone() would never
     // return.
-
     const zx::duration kTimeout = zx::msec(500);
 
     // Don't attach to the thread because otherwise the thread's dispatcher
     // would be set to null when the loop is destroyed, causing any other FIDL
     // code running on the same thread to crash.
     async::Loop loop(&kAsyncLoopConfigNeverAttachToThread);
-
-    fuchsia::intl::PropertyProviderHandle handle;
+    auto endpoints =
+        fidl::Endpoints<fuchsia_intl::PropertyProvider>::Create();
     zx_status_t status = fdio_service_connect_by_name(
-        fuchsia::intl::PropertyProvider::Name_,
-        handle.NewRequest().TakeChannel().release());
+        fidl::DiscoverableProtocolName<fuchsia_intl::PropertyProvider>,
+        endpoints.server.TakeChannel().release());
     if (status != ZX_OK) {
       return;
     }
+    fidl::Client intl_provider(
+        std::move(endpoints.client), loop.dispatcher());
 
-    fuchsia::intl::PropertyProviderPtr intl_provider;
-    status = intl_provider.Bind(std::move(handle), loop.dispatcher());
-    if (status != ZX_OK) {
-      return;
-    }
-
-    intl_provider->GetProfile(
-        [&loop, &primary_tz](fuchsia::intl::Profile profile) {
-          if (!profile.time_zones().empty()) {
-            primary_tz = profile.time_zones()[0].id;
+    // Attempt to initialize the time zone only once, and fail quietly.
+    // The end result of an error is an empty time zone string.
+    intl_provider->GetProfile().Then(
+        [&loop, &primary_tz](
+          fidl::Result<fuchsia_intl::PropertyProvider::GetProfile>& result) {
+          if (result.is_ok()) {
+            const auto& response = result.value();
+            primary_tz = response.profile().time_zones().value()[0].id();
           }
           loop.Quit();
         });


### PR DESCRIPTION
Fuchsia has a code snippet that uses its FIDL IPC mechanism to request time zone information from the host.

The generated FIDL bindings have been changed since this code was first written from the "high level" (HL) CPP bindings to the "new" CPP bindings.

We are now migrating external code to remove the HL CPP bindings to allow FIDL to continue development.  No other platforms should be affected, since the changes are in the sections of the code that is conditionally compiled only when Fuchsia is the target platform.