### PR TITLE
Miscellaneous cleanup for MODULE.bazel and README.md

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -34,4 +34,4 @@ bazel_dep(name = "googletest",
           dev_dependency = True)
 
 bazel_dep(name = "platforms",
-          version = "0.0.8")
+          version = "0.0.10")

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ that should work if you're unable to use Bazel.)
 
 With CMake:
 
-1.  Make sure you have CMake >= 2.8.12 installed.
+1.  Make sure you have CMake >= 3.16 installed.
 2.  Get the cctz source: `git clone https://github.com/google/cctz.git` then `cd
     cctz`.
 3.  Build cctz so that is can be used by shared libraries and run the tests (use


### PR DESCRIPTION
Cleanup a couple of things I noticed during a recent PR:
- Update the 'platforms' version to match the root module.
- Update the documented minimum cmake requirement to match CMakeLists.txt.