### PR TITLE
Fix typo in time_zone.h

### DIFF
--- a/include/cctz/time_zone.h
+++ b/include/cctz/time_zone.h
@@ -198,7 +198,7 @@ class time_zone {
   // version() and description() provide additional information about the
   // time zone. The content of each of the returned strings is unspecified,
   // however, when the IANA Time Zone Database is the underlying data source
-  // the version() string will be in the familar form (e.g, "2018e") or
+  // the version() string will be in the familiar form (e.g, "2018e") or
   // empty when unavailable.
   //
   // Note: These functions are for informational or testing purposes only.


### PR DESCRIPTION
Fix typo in include/cctz/time_zone.h