### PR TITLE
Speculative fix for "No Target Architecture" error

### DIFF
--- a/src/time_zone_lookup.cc
+++ b/src/time_zone_lookup.cc
@@ -37,13 +37,18 @@
 #if defined(__has_include)
 #if __has_include(<icu.h>)
 #define USE_WIN32_LOCAL_TIME_ZONE
-#pragma push_macro("NTDDI_VERSION")
-// ucal_getTimeZoneIDForWindowsID is available on Windows 10 RS3 and later.
-#define NTDDI_VERSION 0x0A000004  // == NTDDI_WIN10_RS3
 #include <windows.h>
+#pragma push_macro("_WIN32_WINNT")
+#pragma push_macro("NTDDI_VERSION")
+// Minimum _WIN32_WINNT and NTDDI_VERSION to use ucal_getTimeZoneIDForWindowsID
+#undef _WIN32_WINNT
+#define _WIN32_WINNT 0x0A00  // == _WIN32_WINNT_WIN10
+#undef NTDDI_VERSION
+#define NTDDI_VERSION 0x0A000004  // == NTDDI_WIN10_RS3
 #include <icu.h>
-#include <timezoneapi.h>
 #pragma pop_macro("NTDDI_VERSION")
+#pragma pop_macro("_WIN32_WINNT")
+#include <timezoneapi.h>
 #include <atomic>
 #endif  // __has_include(<icu.h>)
 #endif  // __has_include


### PR DESCRIPTION
This commit attempts to fix the build failure reported in https://github.com/google/cctz/pull/316#issuecomment-2866482102, which is a consequence of my previous commit (2ebbe0d8a2771f9899839765fe3e651bd2b55382).

With this commit relevant Win32 macros are overridden only while including `<icu.h>`. This commit also overrides `_WIN32_WINNT` to be consistent with `NTDDI_VERSION`.
