### PR TITLE
Fix GCC attribute warning introduced by #319

### DIFF
--- a/include/cctz/civil_time_detail.h
+++ b/include/cctz/civil_time_detail.h
@@ -92,15 +92,15 @@ CONSTEXPR_F int days_per_year(year_t y, month_t m) noexcept {
   return is_leap_year(y + (m > 2)) ? 366 : 365;
 }
 // The compiler cannot optimize away the check if we use
-// fsanitize=array-bounds.
+// -fsanitize=array-bounds.
 // m is guaranteed to be in [1:12] in the caller, but the compiler cannot
 // optimize away the check even when this function is inlined into BreakTime.
 // To reduce the overhead, we use no_sanitize to skip the unnecessary
-// fsanitize=array-bounds check. Remove no_sanitize once the missed
+// -fsanitize=array-bounds check. Remove no_sanitize once the missed
 // optimization is fixed.
-#if defined(__has_attribute)
-#if __has_attribute(no_sanitize)
-__attribute__((no_sanitize("array-bounds")))
+#if defined(__clang__) && defined(__has_cpp_attribute)
+#if __has_cpp_attribute(clang::no_sanitize)
+[[clang::no_sanitize("array-bounds")]]
 #endif
 #endif
 CONSTEXPR_F int days_per_month(year_t y, month_t m) noexcept {


### PR DESCRIPTION
`error: 'array-bounds' attribute directive ignored [-Werror=attributes]`