### PR TITLE
Allow long durations in split_seconds

### DIFF
--- a/include/cctz/time_zone.h
+++ b/include/cctz/time_zone.h
@@ -39,7 +39,7 @@ using sys_seconds = seconds;  // Deprecated.  Use cctz::seconds instead.
 
 namespace detail {
 template <typename D>
-std::pair<time_point<seconds>, D> split_seconds(const time_point<D>& tp);
+std::pair<time_point<seconds>, std::common_type_t<D, seconds>> split_seconds(const time_point<D>& tp);
 std::pair<time_point<seconds>, seconds> split_seconds(
     const time_point<seconds>& tp);
 }  // namespace detail
@@ -381,14 +381,14 @@ namespace detail {
 // cctz::format(fmt, tp, tz) with a time_point that is outside the range
 // of a 64-bit std::time_t.
 template <typename D>
-std::pair<time_point<seconds>, D> split_seconds(const time_point<D>& tp) {
+std::pair<time_point<seconds>, std::common_type_t<D, seconds>> split_seconds(const time_point<D>& tp) {
   auto sec = std::chrono::time_point_cast<seconds>(tp);
   auto sub = tp - sec;
   if (sub.count() < 0) {
     sec -= seconds(1);
     sub += seconds(1);
   }
-  return {sec, std::chrono::duration_cast<D>(sub)};
+  return {sec, sub};
 }
 
 inline std::pair<time_point<seconds>, seconds> split_seconds(


### PR DESCRIPTION
```c++
#include <chrono>

#include <cctz/time_zone.h>

std::string IsoFormat(std::chrono::year_month_day date) {
    return cctz::format("%Y-%m-%d", std::chrono::sys_days{date}, cctz::utc_time_zone());
}

int main() { return 0; }
```

```bash
$ g++ 138_2.cpp -std=c++23
138_2.cpp: In function ‘std::string IsoFormat(std::chrono::year_month_day)’:
138_2.cpp:6:66: error: no matching function for call to ‘std::chrono::time_point<std::chrono::_V2::system_clock, std::chrono::duration<long int> >::time_point(<brace-enclosed initializer list>)’
    6 |     return  cctz::format("%Y-%m-%d",std::chrono::sys_seconds{date}, cctz::local_time_zone());
      |                                                                  ^
In file included from /usr/include/c++/13/chrono:41,
                 from 138_2.cpp:1:
/usr/include/c++/13/bits/chrono.h:943:21: note: candidate: ‘template<class _Dur2, class> constexpr std::chrono::time_point<_Clock, _Dur>::time_point(const std::chrono::time_point<_Clock, _Dur2>&) [with <template-parameter-2-2> = _Dur2; _Clock = std::chrono::_V2::system_clock; _Dur = std::chrono::duration<long int>]’
  943 |           constexpr time_point(const time_point<clock, _Dur2>& __t)
      |                     ^~~~~~~~~~
/usr/include/c++/13/bits/chrono.h:943:21: note:   template argument deduction/substitution failed:
138_2.cpp:6:66: note:   ‘std::chrono::year_month_day’ is not derived from ‘const std::chrono::time_point<std::chrono::_V2::system_clock, _Dur2>’
    6 |     return  cctz::format("%Y-%m-%d",std::chrono::sys_seconds{date}, cctz::local_time_zone());
      |                                                                  ^
/usr/include/c++/13/bits/chrono.h:936:28: note: candidate: ‘constexpr std::chrono::time_point<_Clock, _Dur>::time_point(const duration&) [with _Clock = std::chrono::_V2::system_clock; _Dur = std::chrono::duration<long int>; duration = std::chrono::duration<long int>]’
  936 |         constexpr explicit time_point(const duration& __dur)
      |                            ^~~~~~~~~~
/usr/include/c++/13/bits/chrono.h:936:55: note:   no known conversion for argument 1 from ‘std::chrono::year_month_day’ to ‘const std::chrono::time_point<std::chrono::_V2::system_clock, std::chrono::duration<long int> >::duration&’ {aka ‘const std::chrono::duration<long int>&’}
  936 |         constexpr explicit time_point(const duration& __dur)
      |                                       ~~~~~~~~~~~~~~~~^~~~~
/usr/include/c++/13/bits/chrono.h:933:19: note: candidate: ‘constexpr std::chrono::time_point<_Clock, _Dur>::time_point() [with _Clock = std::chrono::_V2::system_clock; _Dur = std::chrono::duration<long int>]’
  933 |         constexpr time_point() : __d(duration::zero())
      |                   ^~~~~~~~~~
/usr/include/c++/13/bits/chrono.h:933:19: note:   candidate expects 0 arguments, 1 provided
/usr/include/c++/13/bits/chrono.h:922:13: note: candidate: ‘constexpr std::chrono::time_point<std::chrono::_V2::system_clock, std::chrono::duration<long int> >::time_point(const std::chrono::time_point<std::chrono::_V2::system_clock, std::chrono::duration<long int> >&)’
  922 |       class time_point
      |             ^~~~~~~~~~
/usr/include/c++/13/bits/chrono.h:922:13: note:   no known conversion for argument 1 from ‘std::chrono::year_month_day’ to ‘const std::chrono::time_point<std::chrono::_V2::system_clock, std::chrono::duration<long int> >&’
/usr/include/c++/13/bits/chrono.h:922:13: note: candidate: ‘constexpr std::chrono::time_point<std::chrono::_V2::system_clock, std::chrono::duration<long int> >::time_point(std::chrono::time_point<std::chrono::_V2::system_clock, std::chrono::duration<long int> >&&)’
/usr/include/c++/13/bits/chrono.h:922:13: note:   no known conversion for argument 1 from ‘std::chrono::year_month_day’ to ‘std::chrono::time_point<std::chrono::_V2::system_clock, std::chrono::duration<long int> >&&’
(taxi-py3-2) romankoshelev@romankoshelev-lin:~/expiriments/cctz$ g++ 138_2.cpp -std=c++23 
In file included from /usr/include/c++/13/bits/chrono.h:37,
                 from /usr/include/c++/13/chrono:41,
                 from 138_2.cpp:1:
/usr/include/c++/13/ratio: In instantiation of ‘struct std::__safe_multiply<86400, 1000000000000000>’:
/usr/include/c++/13/ratio:340:54:   required from ‘struct std::__ratio_multiply<std::ratio<86400>, std::ratio<1000000000000000, 1> >’
/usr/include/c++/13/ratio:369:42:   required from ‘struct std::__ratio_divide<std::ratio<86400>, std::ratio<1, 1000000000000000> >’
/usr/include/c++/13/ratio:387:11:   required by substitution of ‘template<class _R1, class _R2> using std::ratio_divide = typename std::__ratio_divide::type [with _R1 = std::ratio<86400>; _R2 = std::ratio<1, 1000000000000000>]’
/usr/include/c++/13/bits/chrono.h:283:10:   required from ‘constexpr std::chrono::__enable_if_is_duration<_ToDur> std::chrono::duration_cast(const duration<_Rep, _Period>&) [with _ToDur = duration<long int, std::ratio<1, 1000000000000000> >; _Rep = long int; _Period = std::ratio<86400>; __enable_if_is_duration<_ToDur> = duration<long int, std::ratio<1, 1000000000000000> >]’
/usr/include/cctz/time_zone.h:311:66:   required from ‘std::string cctz::format(const std::string&, time_point<D>&, const time_zone&) [with D = std::chrono::duration<long int, std::ratio<86400> >; std::string = std::__cxx11::basic_string<char>; time_point<D> = std::chrono::time_point<std::chrono::_V2::system_clock, std::chrono::duration<long int, std::ratio<86400> > >]’
138_2.cpp:6:25:   required from here
/usr/include/c++/13/ratio:100:47: error: static assertion failed: overflow in multiplication
  100 |       static_assert(__a0 * __b1 + __b0 * __a1 < (__c >> 1),
      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
/usr/include/c++/13/ratio:100:47: note: the comparison reduces to ‘(20116512000 < 2147483648)’
/usr/include/c++/13/ratio:105:21: error: static assertion failed: overflow in multiplication
  104 |       static_assert((__a0 * __b1 + __b0 * __a1) * __c
      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  105 |                     <= __INTMAX_MAX__ -  __b0 * __a0,
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/13/ratio:105:21: note: the comparison reduces to ‘(12612784854753345536 <= 9223133186446327807)’
/usr/include/c++/13/ratio: In instantiation of ‘const intmax_t std::__safe_multiply<86400, 1000000000000000>::value’:
/usr/include/c++/13/ratio:340:54:   required from ‘struct std::__ratio_multiply<std::ratio<86400>, std::ratio<1000000000000000, 1> >’
/usr/include/c++/13/ratio:369:42:   required from ‘struct std::__ratio_divide<std::ratio<86400>, std::ratio<1, 1000000000000000> >’
/usr/include/c++/13/ratio:387:11:   required by substitution of ‘template<class _R1, class _R2> using std::ratio_divide = typename std::__ratio_divide::type [with _R1 = std::ratio<86400>; _R2 = std::ratio<1, 1000000000000000>]’
/usr/include/c++/13/bits/chrono.h:283:10:   required from ‘constexpr std::chrono::__enable_if_is_duration<_ToDur> std::chrono::duration_cast(const duration<_Rep, _Period>&) [with _ToDur = duration<long int, std::ratio<1, 1000000000000000> >; _Rep = long int; _Period = std::ratio<86400>; __enable_if_is_duration<_ToDur> = duration<long int, std::ratio<1, 1000000000000000> >]’
/usr/include/cctz/time_zone.h:311:66:   required from ‘std::string cctz::format(const std::string&, time_point<D>&, const time_zone&) [with D = std::chrono::duration<long int, std::ratio<86400> >; std::string = std::__cxx11::basic_string<char>; time_point<D> = std::chrono::time_point<std::chrono::_V2::system_clock, std::chrono::duration<long int, std::ratio<86400> > >]’
138_2.cpp:6:25:   required from here
/usr/include/c++/13/ratio:109:29: error: overflow in constant expression [-fpermissive]
  109 |       static const intmax_t value = _Pn * _Qn;
      |                             ^~~~~
/usr/include/c++/13/ratio:109:29: error: overflow in constant expression [-fpermissive]
(taxi-py3-2) romankoshelev@romankoshelev-lin:~/expiriments/cctz$ g++ 138_2.cpp -std=c++23 
In file included from /usr/include/c++/13/bits/chrono.h:37,
                 from /usr/include/c++/13/chrono:41,
                 from 138_2.cpp:1:
/usr/include/c++/13/ratio: In instantiation of ‘struct std::__safe_multiply<86400, 1000000000000000>’:
/usr/include/c++/13/ratio:340:54:   required from ‘struct std::__ratio_multiply<std::ratio<86400>, std::ratio<1000000000000000, 1> >’
/usr/include/c++/13/ratio:369:42:   required from ‘struct std::__ratio_divide<std::ratio<86400>, std::ratio<1, 1000000000000000> >’
/usr/include/c++/13/ratio:387:11:   required by substitution of ‘template<class _R1, class _R2> using std::ratio_divide = typename std::__ratio_divide::type [with _R1 = std::ratio<86400>; _R2 = std::ratio<1, 1000000000000000>]’
/usr/include/c++/13/bits/chrono.h:283:10:   required from ‘constexpr std::chrono::__enable_if_is_duration<_ToDur> std::chrono::duration_cast(const duration<_Rep, _Period>&) [with _ToDur = duration<long int, std::ratio<1, 1000000000000000> >; _Rep = long int; _Period = std::ratio<86400>; __enable_if_is_duration<_ToDur> = duration<long int, std::ratio<1, 1000000000000000> >]’
/usr/include/cctz/time_zone.h:311:66:   required from ‘std::string cctz::format(const std::string&, time_point<D>&, const time_zone&) [with D = std::chrono::duration<long int, std::ratio<86400> >; std::string = std::__cxx11::basic_string<char>; time_point<D> = std::chrono::time_point<std::chrono::_V2::system_clock, std::chrono::duration<long int, std::ratio<86400> > >]’
138_2.cpp:6:24:   required from here
/usr/include/c++/13/ratio:100:47: error: static assertion failed: overflow in multiplication
  100 |       static_assert(__a0 * __b1 + __b0 * __a1 < (__c >> 1),
      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
/usr/include/c++/13/ratio:100:47: note: the comparison reduces to ‘(20116512000 < 2147483648)’
/usr/include/c++/13/ratio:105:21: error: static assertion failed: overflow in multiplication
  104 |       static_assert((__a0 * __b1 + __b0 * __a1) * __c
      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  105 |                     <= __INTMAX_MAX__ -  __b0 * __a0,
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/13/ratio:105:21: note: the comparison reduces to ‘(12612784854753345536 <= 9223133186446327807)’
/usr/include/c++/13/ratio: In instantiation of ‘const intmax_t std::__safe_multiply<86400, 1000000000000000>::value’:
/usr/include/c++/13/ratio:340:54:   required from ‘struct std::__ratio_multiply<std::ratio<86400>, std::ratio<1000000000000000, 1> >’
/usr/include/c++/13/ratio:369:42:   required from ‘struct std::__ratio_divide<std::ratio<86400>, std::ratio<1, 1000000000000000> >’
/usr/include/c++/13/ratio:387:11:   required by substitution of ‘template<class _R1, class _R2> using std::ratio_divide = typename std::__ratio_divide::type [with _R1 = std::ratio<86400>; _R2 = std::ratio<1, 1000000000000000>]’
/usr/include/c++/13/bits/chrono.h:283:10:   required from ‘constexpr std::chrono::__enable_if_is_duration<_ToDur> std::chrono::duration_cast(const duration<_Rep, _Period>&) [with _ToDur = duration<long int, std::ratio<1, 1000000000000000> >; _Rep = long int; _Period = std::ratio<86400>; __enable_if_is_duration<_ToDur> = duration<long int, std::ratio<1, 1000000000000000> >]’
/usr/include/cctz/time_zone.h:311:66:   required from ‘std::string cctz::format(const std::string&, time_point<D>&, const time_zone&) [with D = std::chrono::duration<long int, std::ratio<86400> >; std::string = std::__cxx11::basic_string<char>; time_point<D> = std::chrono::time_point<std::chrono::_V2::system_clock, std::chrono::duration<long int, std::ratio<86400> > >]’
138_2.cpp:6:24:   required from here
/usr/include/c++/13/ratio:109:29: error: overflow in constant expression [-fpermissive]
  109 |       static const intmax_t value = _Pn * _Qn;
      |                             ^~~~~
/usr/include/c++/13/ratio:109:29: error: overflow in constant expression [-fpermissive]
```