### PR TITLE
Update the time_point used in Format.PosixConversions

### DIFF
--- a/src/time_zone_format.cc
+++ b/src/time_zone_format.cc
@@ -113,7 +113,7 @@ std::tm ToTM(const time_zone::absolute_lookup& al) {
   tm.tm_mday = al.cs.day();
   tm.tm_mon = al.cs.month() - 1;
 
-  // Saturate tm.tm_year is cases of over/underflow.
+  // Saturate tm.tm_year in cases of over/underflow.
   if (al.cs.year() < std::numeric_limits<int>::min() + 1900) {
     tm.tm_year = std::numeric_limits<int>::min();
   } else if (al.cs.year() - 1900 > std::numeric_limits<int>::max()) {

--- a/src/time_zone_format_test.cc
+++ b/src/time_zone_format_test.cc
@@ -158,21 +158,22 @@ TEST(Format, Basics) {
 
 TEST(Format, PosixConversions) {
   const time_zone tz = utc_time_zone();
-  auto tp = chrono::system_clock::from_time_t(0);
+  auto tp =
+      chrono::system_clock::from_time_t(308189482); // 1979-10-08T00:11:22Z
 
-  TestFormatSpecifier(tp, tz, "%d", "01");
-  TestFormatSpecifier(tp, tz, "%e", " 1");  // extension but internal support
+  TestFormatSpecifier(tp, tz, "%d", "08");
+  TestFormatSpecifier(tp, tz, "%e", " 8");  // extension but internal support
   TestFormatSpecifier(tp, tz, "%H", "00");
   TestFormatSpecifier(tp, tz, "%I", "12");
-  TestFormatSpecifier(tp, tz, "%j", "001");
-  TestFormatSpecifier(tp, tz, "%m", "01");
-  TestFormatSpecifier(tp, tz, "%M", "00");
-  TestFormatSpecifier(tp, tz, "%S", "00");
-  TestFormatSpecifier(tp, tz, "%U", "00");
-  TestFormatSpecifier(tp, tz, "%w", "4");  // 4=Thursday
-  TestFormatSpecifier(tp, tz, "%W", "00");
-  TestFormatSpecifier(tp, tz, "%y", "70");
-  TestFormatSpecifier(tp, tz, "%Y", "1970");
+  TestFormatSpecifier(tp, tz, "%j", "281");
+  TestFormatSpecifier(tp, tz, "%m", "10");
+  TestFormatSpecifier(tp, tz, "%M", "11");
+  TestFormatSpecifier(tp, tz, "%S", "22");
+  TestFormatSpecifier(tp, tz, "%U", "40");
+  TestFormatSpecifier(tp, tz, "%w", "1");  // 1=Monday
+  TestFormatSpecifier(tp, tz, "%W", "41");
+  TestFormatSpecifier(tp, tz, "%y", "79");
+  TestFormatSpecifier(tp, tz, "%Y", "1979");
   TestFormatSpecifier(tp, tz, "%z", "+0000");
   TestFormatSpecifier(tp, tz, "%Z", "UTC");
   TestFormatSpecifier(tp, tz, "%%", "%");
@@ -180,21 +181,21 @@ TEST(Format, PosixConversions) {
 #if defined(__linux__)
   // SU/C99/TZ extensions
   TestFormatSpecifier(tp, tz, "%C", "19");
-  TestFormatSpecifier(tp, tz, "%D", "01/01/70");
-  TestFormatSpecifier(tp, tz, "%F", "1970-01-01");
-  TestFormatSpecifier(tp, tz, "%g", "70");
-  TestFormatSpecifier(tp, tz, "%G", "1970");
+  TestFormatSpecifier(tp, tz, "%D", "10/08/79");
+  TestFormatSpecifier(tp, tz, "%F", "1979-10-08");
+  TestFormatSpecifier(tp, tz, "%g", "79");
+  TestFormatSpecifier(tp, tz, "%G", "1979");
 #if defined(__GLIBC__)
   TestFormatSpecifier(tp, tz, "%k", " 0");
   TestFormatSpecifier(tp, tz, "%l", "12");
 #endif
   TestFormatSpecifier(tp, tz, "%n", "\n");
-  TestFormatSpecifier(tp, tz, "%R", "00:00");
+  TestFormatSpecifier(tp, tz, "%R", "00:11");
   TestFormatSpecifier(tp, tz, "%t", "\t");
-  TestFormatSpecifier(tp, tz, "%T", "00:00:00");
-  TestFormatSpecifier(tp, tz, "%u", "4");  // 4=Thursday
-  TestFormatSpecifier(tp, tz, "%V", "01");
-  TestFormatSpecifier(tp, tz, "%s", "0");
+  TestFormatSpecifier(tp, tz, "%T", "00:11:22");
+  TestFormatSpecifier(tp, tz, "%u", "1");  // 1=Monday
+  TestFormatSpecifier(tp, tz, "%V", "41");
+  TestFormatSpecifier(tp, tz, "%s", "308189482");
 #endif
 }
 


### PR DESCRIPTION
Use a `time_point` in the Format.PosixConversions test cases that produces more distinct values for each of the conversion specifiers, which increases the confidence that we are assigning them correctly.

Also correct a comment typo in `time_zone_format.cc:ToTM()` while we are here.