### PR TITLE
Make cctz::ParseDateTime() return NULL on failure

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -159,6 +159,21 @@ cc_test(
     ],
 )
 
+cc_test(
+    name = "time_zone_posix_test",
+    size = "small",
+    srcs = [
+      "src/time_zone_posix_test.cc",
+      "src/time_zone_posix.h",
+    ],
+    deps = [
+        ":civil_time",
+        ":time_zone",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+    ],
+)
+
 ### benchmarks
 
 cc_test(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,6 +151,16 @@ if (BUILD_TESTING)
   add_test(time_zone_format_test time_zone_format_test)
   list(APPEND CCTZ_TESTS time_zone_format_test)
 
+  add_executable(time_zone_posix_test src/time_zone_posix_test.cc)
+  cctz_target_set_cxx_standard(time_zone_posix_test)
+  target_link_libraries(time_zone_posix_test
+    cctz::cctz
+    ${CMAKE_THREAD_LIBS_INIT}
+    GMock::Main
+    )
+  add_test(time_zone_posix_test time_zone_posix_test)
+  list(APPEND CCTZ_TESTS time_zone_posix_test)
+
   if(WIN32)
     add_executable(time_zone_name_win_test src/time_zone_name_win_test.cc)
     cctz_target_set_cxx_standard(time_zone_name_win_test)

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ PREFIX ?= /usr/local
 DESTDIR ?=
 
 # possible support for googletest
-## TESTS = civil_time_test time_zone_lookup_test time_zone_format_test
+## TESTS = civil_time_test time_zone_lookup_test time_zone_format_test time_zone_posix_test
 ## TEST_FLAGS = ...
 ## TEST_LIBS = ...
 

--- a/src/time_zone_posix.cc
+++ b/src/time_zone_posix.cc
@@ -87,14 +87,17 @@ const char* ParseOffset(const char* p, int min_hour, int max_hour, int sign,
   return p;
 }
 
-// datetime = ( Jn | n | Mm.w.d ) [ / offset ]
+// datetime = , ( Jn | n | Mm.w.d ) [ / offset ]
 const char* ParseDateTime(const char* p, PosixTransition* res) {
-  if (p != nullptr && *p == ',') {
+  if (p != nullptr) {
+    if (*p != ',') return nullptr;
     if (*++p == 'M') {
       int month = 0;
-      if ((p = ParseInt(p + 1, 1, 12, &month)) != nullptr && *p == '.') {
+      if ((p = ParseInt(p + 1, 1, 12, &month)) != nullptr) {
+        if (*p != '.') return nullptr;
         int week = 0;
-        if ((p = ParseInt(p + 1, 1, 5, &week)) != nullptr && *p == '.') {
+        if ((p = ParseInt(p + 1, 1, 5, &week)) != nullptr) {
+          if (*p != '.') return nullptr;
           int weekday = 0;
           if ((p = ParseInt(p + 1, 0, 6, &weekday)) != nullptr) {
             res->date.fmt = PosixTransition::M;
@@ -117,10 +120,10 @@ const char* ParseDateTime(const char* p, PosixTransition* res) {
         res->date.n.day = static_cast<std::int_fast16_t>(day);
       }
     }
-  }
-  if (p != nullptr) {
-    res->time.offset = 2 * 60 * 60;  // default offset is 02:00:00
-    if (*p == '/') p = ParseOffset(p + 1, -167, 167, 1, &res->time.offset);
+    if (p != nullptr) {
+      res->time.offset = 2 * 60 * 60;  // default offset is 02:00:00
+      if (*p == '/') p = ParseOffset(p + 1, -167, 167, 1, &res->time.offset);
+    }
   }
   return p;
 }

--- a/src/time_zone_posix_test.cc
+++ b/src/time_zone_posix_test.cc
@@ -1,0 +1,26 @@
+// Copyright 2026 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+#include "time_zone_posix.h"
+
+#include "gtest/gtest.h"
+
+namespace cctz {
+
+TEST(TimeZonePosix, ParsePosixSpec) {
+  PosixTimeZone zone;
+  EXPECT_FALSE(ParsePosixSpec("PST8PDT7", &zone));
+}
+
+}  // namespace cctz


### PR DESCRIPTION
Prevents uninitialized data from being returned when the input is malformed (say, when the footer is `\nPST8PDT,M3\n`).