### PR TITLE
Avoid DoS attacks via loading of invalid untrusted timezones

### DIFF
--- a/src/time_zone_impl.cc
+++ b/src/time_zone_impl.cc
@@ -74,9 +74,18 @@ bool time_zone::Impl::LoadTimeZone(const std::string& name, time_zone* tz) {
   // Add the new time zone to the map.
   std::lock_guard<std::mutex> lock(TimeZoneMutex());
   if (time_zone_map == nullptr) time_zone_map = new TimeZoneImplByName;
+  if (!new_impl->zone_) {
+    // Load failed, but a successful insertion may have happened concurrently.
+    // Check it now that we have the lock. Otherwise, avoid caching negative
+    // entries to avoid unbounded growth and DoS attacks.
+    auto itr = time_zone_map->find(name);
+    const Impl* impl = (itr != time_zone_map->end()) ? itr->second : utc_impl;
+    *tz = time_zone(impl);
+    return impl != utc_impl;
+  }
   const Impl*& impl = (*time_zone_map)[name];
   if (impl == nullptr) {  // this thread won any load race
-    impl = new_impl->zone_ ? new_impl.release() : utc_impl;
+    impl = new_impl.release();
   }
   *tz = time_zone(impl);
   return impl != utc_impl;


### PR DESCRIPTION
Currently, `absl::LoadTimeZone` API caches all queried time zone names, including invalid ones, in a process-global map without any eviction mechanism. An attacker supplying numerous distinct or colliding strings can trigger unbounded memory growth and severe thread serialization. The underlying map uses an unseeded hash function, exacerbating the denial-of-service via global lock contention.

This change avoids caching failed loads.