### PR TITLE
pass unsigned char to ctype functions in parse()

### DIFF
--- a/src/time_tool.cc
+++ b/src/time_tool.cc
@@ -239,9 +239,11 @@ const char* Basename(const char* p) {
 
 // std::regex doesn't work before gcc 4.9.
 bool LooksLikeNegOffset(const char* s) {
-  if (s[0] == '-' && std::isdigit(s[1]) && std::isdigit(s[2])) {
+  if (s[0] == '-' && std::isdigit(static_cast<unsigned char>(s[1])) &&
+      std::isdigit(static_cast<unsigned char>(s[2]))) {
     int i = (s[3] == ':') ? 4 : 3;
-    if (std::isdigit(s[i]) && std::isdigit(s[i + 1])) {
+    if (std::isdigit(static_cast<unsigned char>(s[i])) &&
+        std::isdigit(static_cast<unsigned char>(s[i + 1]))) {
       return s[i + 2] == '\0';
     }
   }
@@ -270,7 +272,8 @@ bool ParseYearRange(bool zdump, const std::string& args,
                     cctz::year_t* lo_year, cctz::year_t* hi_year) {
   std::size_t pos = 0;
   std::size_t digit_pos = pos + (args[pos] == '-' ? 1 : 0);
-  if (digit_pos >= args.size() || !std::isdigit(args[digit_pos])) {
+  if (digit_pos >= args.size() ||
+      !std::isdigit(static_cast<unsigned char>(args[digit_pos]))) {
     return false;
   }
   const cctz::year_t first = std::stoll(args, &pos);
@@ -284,7 +287,8 @@ bool ParseYearRange(bool zdump, const std::string& args,
     return false;
   }
   digit_pos = pos + (args[pos] == '-' ? 1 : 0);
-  if (digit_pos >= args.size() || !std::isdigit(args[digit_pos])) {
+  if (digit_pos >= args.size() ||
+      !std::isdigit(static_cast<unsigned char>(args[digit_pos]))) {
     return false;
   }
   const std::string rem = args.substr(pos);
@@ -417,8 +421,10 @@ int main(int argc, const char** argv) {
   bool have_time = ParseTimeSpec(args, &tp);
   if (!have_time && !args.empty()) {
     std::string spec = args.substr((args[0] == '@') ? 1 : 0);
-    if ((spec.size() > 0 && std::isdigit(spec[0])) ||
-        (spec.size() > 1 && spec[0] == '-' && std::isdigit(spec[1]))) {
+    if ((spec.size() > 0 &&
+         std::isdigit(static_cast<unsigned char>(spec[0]))) ||
+        (spec.size() > 1 && spec[0] == '-' &&
+         std::isdigit(static_cast<unsigned char>(spec[1])))) {
       std::size_t end;
       const time_t t = std::stoll(spec, &end);
       if (end == spec.size()) {

--- a/src/time_tool.cc
+++ b/src/time_tool.cc
@@ -237,13 +237,17 @@ const char* Basename(const char* p) {
   return p;
 }
 
+// The ctype functions have undefined behavior for negative char values,
+// so this helper ensures the argument is always in the unsigned-char domain.
+bool isdigit(char ch) {
+  return std::isdigit(static_cast<unsigned char>(ch)) != 0;
+}
+
 // std::regex doesn't work before gcc 4.9.
 bool LooksLikeNegOffset(const char* s) {
-  if (s[0] == '-' && std::isdigit(static_cast<unsigned char>(s[1])) &&
-      std::isdigit(static_cast<unsigned char>(s[2]))) {
+  if (s[0] == '-' && isdigit(s[1]) && isdigit(s[2])) {
     int i = (s[3] == ':') ? 4 : 3;
-    if (std::isdigit(static_cast<unsigned char>(s[i])) &&
-        std::isdigit(static_cast<unsigned char>(s[i + 1]))) {
+    if (isdigit(s[i]) && isdigit(s[i + 1])) {
       return s[i + 2] == '\0';
     }
   }
@@ -272,8 +276,7 @@ bool ParseYearRange(bool zdump, const std::string& args,
                     cctz::year_t* lo_year, cctz::year_t* hi_year) {
   std::size_t pos = 0;
   std::size_t digit_pos = pos + (args[pos] == '-' ? 1 : 0);
-  if (digit_pos >= args.size() ||
-      !std::isdigit(static_cast<unsigned char>(args[digit_pos]))) {
+  if (digit_pos >= args.size() || !isdigit(args[digit_pos])) {
     return false;
   }
   const cctz::year_t first = std::stoll(args, &pos);
@@ -287,8 +290,7 @@ bool ParseYearRange(bool zdump, const std::string& args,
     return false;
   }
   digit_pos = pos + (args[pos] == '-' ? 1 : 0);
-  if (digit_pos >= args.size() ||
-      !std::isdigit(static_cast<unsigned char>(args[digit_pos]))) {
+  if (digit_pos >= args.size() || !isdigit(args[digit_pos])) {
     return false;
   }
   const std::string rem = args.substr(pos);
@@ -421,10 +423,8 @@ int main(int argc, const char** argv) {
   bool have_time = ParseTimeSpec(args, &tp);
   if (!have_time && !args.empty()) {
     std::string spec = args.substr((args[0] == '@') ? 1 : 0);
-    if ((spec.size() > 0 &&
-         std::isdigit(static_cast<unsigned char>(spec[0]))) ||
-        (spec.size() > 1 && spec[0] == '-' &&
-         std::isdigit(static_cast<unsigned char>(spec[1])))) {
+    if ((spec.size() > 0 && isdigit(spec[0])) ||
+        (spec.size() > 1 && spec[0] == '-' && isdigit(spec[1]))) {
       std::size_t end;
       const time_t t = std::stoll(spec, &end);
       if (end == spec.size()) {

--- a/src/time_zone_format.cc
+++ b/src/time_zone_format.cc
@@ -54,6 +54,16 @@ namespace detail {
 
 namespace {
 
+// The ctype functions have undefined behavior for negative char values,
+// so these helpers ensure the argument is always in the unsigned-char domain.
+bool isdigit(char ch) {
+  return std::isdigit(static_cast<unsigned char>(ch)) != 0;
+}
+
+bool isspace(char ch) {
+  return std::isspace(static_cast<unsigned char>(ch)) != 0;
+}
+
 #if !HAS_STRPTIME
 // Build a strptime() using C++11's std::get_time().
 char* strptime(const char* s, const char* fmt, std::tm* tm) {
@@ -549,7 +559,7 @@ std::string format(const std::string& format, const time_point<seconds>& tp,
       bp = Format64(ep, 4, al.cs.year());
       result.append(bp, ep);
       pending = cur += 2;
-    } else if (std::isdigit(static_cast<unsigned char>(*cur))) {
+    } else if (isdigit(*cur)) {
       // Possibly found %E#S or %E#f.
       int n = 0;
       if (const char* np = ParseInt(cur, 0, 0, 1024, &n)) {
@@ -615,8 +625,7 @@ const char* ParseOffset(const char* dp, const char* mode, int* offset) {
 const char* ParseZone(const char* dp, std::string* zone) {
   zone->clear();
   if (dp != nullptr) {
-    while (*dp != '\0' && !std::isspace(static_cast<unsigned char>(*dp)))
-      zone->push_back(*dp++);
+    while (*dp != '\0' && !isspace(*dp)) zone->push_back(*dp++);
     if (zone->empty()) dp = nullptr;
   }
   return dp;
@@ -702,7 +711,7 @@ bool parse(const std::string& format, const std::string& input,
   const char* const edata = data + input.size();
 
   // Skips leading whitespace.
-  while (std::isspace(static_cast<unsigned char>(*data))) ++data;
+  while (isspace(*data)) ++data;
 
   const year_t kyearmax = std::numeric_limits<year_t>::max();
   const year_t kyearmin = std::numeric_limits<year_t>::min();
@@ -740,9 +749,9 @@ bool parse(const std::string& format, const std::string& input,
 
   // Steps through format, one specifier at a time.
   while (data != nullptr && fmt != efmt) {
-    if (std::isspace(static_cast<unsigned char>(*fmt))) {
-      while (std::isspace(static_cast<unsigned char>(*data))) ++data;
-      while (std::isspace(static_cast<unsigned char>(*++fmt))) continue;
+    if (isspace(*fmt)) {
+      while (isspace(*data)) ++data;
+      while (isspace(*++fmt)) continue;
       continue;
     }
 
@@ -895,8 +904,7 @@ bool parse(const std::string& format, const std::string& input,
           continue;
         }
         if (fmt[0] == '*' && fmt[1] == 'f') {
-          if (data != nullptr &&
-              std::isdigit(static_cast<unsigned char>(*data))) {
+          if (data != nullptr && isdigit(*data)) {
             data = ParseSubSeconds(data, &subseconds);
           }
           fmt += 2;
@@ -915,7 +923,7 @@ bool parse(const std::string& format, const std::string& input,
           fmt += 2;
           continue;
         }
-        if (std::isdigit(static_cast<unsigned char>(*fmt))) {
+        if (isdigit(*fmt)) {
           int n = 0;  // value ignored
           if (const char* np = ParseInt(fmt, 0, 0, 1024, &n)) {
             if (*np == 'S') {
@@ -927,8 +935,7 @@ bool parse(const std::string& format, const std::string& input,
               continue;
             }
             if (*np == 'f') {
-              if (data != nullptr &&
-                  std::isdigit(static_cast<unsigned char>(*data))) {
+              if (data != nullptr && isdigit(*data)) {
                 data = ParseSubSeconds(data, &subseconds);
               }
               fmt = ++np;
@@ -976,7 +983,7 @@ bool parse(const std::string& format, const std::string& input,
   }
 
   // Skip any remaining whitespace.
-  while (std::isspace(static_cast<unsigned char>(*data))) ++data;
+  while (isspace(*data)) ++data;
 
   // parse() must consume the entire input string.
   if (data != edata) {

--- a/src/time_zone_format.cc
+++ b/src/time_zone_format.cc
@@ -549,7 +549,7 @@ std::string format(const std::string& format, const time_point<seconds>& tp,
       bp = Format64(ep, 4, al.cs.year());
       result.append(bp, ep);
       pending = cur += 2;
-    } else if (std::isdigit(*cur)) {
+    } else if (std::isdigit(static_cast<unsigned char>(*cur))) {
       // Possibly found %E#S or %E#f.
       int n = 0;
       if (const char* np = ParseInt(cur, 0, 0, 1024, &n)) {
@@ -615,7 +615,8 @@ const char* ParseOffset(const char* dp, const char* mode, int* offset) {
 const char* ParseZone(const char* dp, std::string* zone) {
   zone->clear();
   if (dp != nullptr) {
-    while (*dp != '\0' && !std::isspace(*dp)) zone->push_back(*dp++);
+    while (*dp != '\0' && !std::isspace(static_cast<unsigned char>(*dp)))
+      zone->push_back(*dp++);
     if (zone->empty()) dp = nullptr;
   }
   return dp;
@@ -701,7 +702,7 @@ bool parse(const std::string& format, const std::string& input,
   const char* const edata = data + input.size();
 
   // Skips leading whitespace.
-  while (std::isspace(*data)) ++data;
+  while (std::isspace(static_cast<unsigned char>(*data))) ++data;
 
   const year_t kyearmax = std::numeric_limits<year_t>::max();
   const year_t kyearmin = std::numeric_limits<year_t>::min();
@@ -739,9 +740,9 @@ bool parse(const std::string& format, const std::string& input,
 
   // Steps through format, one specifier at a time.
   while (data != nullptr && fmt != efmt) {
-    if (std::isspace(*fmt)) {
-      while (std::isspace(*data)) ++data;
-      while (std::isspace(*++fmt)) continue;
+    if (std::isspace(static_cast<unsigned char>(*fmt))) {
+      while (std::isspace(static_cast<unsigned char>(*data))) ++data;
+      while (std::isspace(static_cast<unsigned char>(*++fmt))) continue;
       continue;
     }
 
@@ -894,7 +895,8 @@ bool parse(const std::string& format, const std::string& input,
           continue;
         }
         if (fmt[0] == '*' && fmt[1] == 'f') {
-          if (data != nullptr && std::isdigit(*data)) {
+          if (data != nullptr &&
+              std::isdigit(static_cast<unsigned char>(*data))) {
             data = ParseSubSeconds(data, &subseconds);
           }
           fmt += 2;
@@ -913,7 +915,7 @@ bool parse(const std::string& format, const std::string& input,
           fmt += 2;
           continue;
         }
-        if (std::isdigit(*fmt)) {
+        if (std::isdigit(static_cast<unsigned char>(*fmt))) {
           int n = 0;  // value ignored
           if (const char* np = ParseInt(fmt, 0, 0, 1024, &n)) {
             if (*np == 'S') {
@@ -925,7 +927,8 @@ bool parse(const std::string& format, const std::string& input,
               continue;
             }
             if (*np == 'f') {
-              if (data != nullptr && std::isdigit(*data)) {
+              if (data != nullptr &&
+                  std::isdigit(static_cast<unsigned char>(*data))) {
                 data = ParseSubSeconds(data, &subseconds);
               }
               fmt = ++np;
@@ -973,7 +976,7 @@ bool parse(const std::string& format, const std::string& input,
   }
 
   // Skip any remaining whitespace.
-  while (std::isspace(*data)) ++data;
+  while (std::isspace(static_cast<unsigned char>(*data))) ++data;
 
   // parse() must consume the entire input string.
   if (data != edata) {

--- a/src/time_zone_format_test.cc
+++ b/src/time_zone_format_test.cc
@@ -927,6 +927,21 @@ TEST(Parse, ErrorCases) {
   EXPECT_FALSE(parse("%Ez", "-00:-0", tz, &tp));
 }
 
+TEST(Parse, NonAsciiInput) {
+  const time_zone tz = utc_time_zone();
+  auto tp = chrono::system_clock::from_time_t(0);
+
+  // High-bit-set bytes reach the ctype functions during parsing. 0xA0 is not
+  // ASCII whitespace, so the leading-whitespace skip must not consume it and
+  // the parse must fail rather than pass a negative char to std::isspace().
+  EXPECT_FALSE(parse("%Y-%m-%d", "\xA0" "2016-01-02", tz, &tp));
+  EXPECT_FALSE(parse("%Y", "\xA0" "2016", tz, &tp));
+
+  // A leading ASCII space is still skipped as before.
+  EXPECT_TRUE(parse("%Y-%m-%d", " 2016-01-02", tz, &tp));
+  EXPECT_EQ(2016, convert(tp, utc_time_zone()).year());
+}
+
 TEST(Parse, PosixConversions) {
   time_zone tz = utc_time_zone();
   auto tp = chrono::system_clock::from_time_t(0);


### PR DESCRIPTION
Repro: call `cctz::parse("%Y-%m-%d", "\xA0...", ...)` with any untrusted input byte >= 0x80.
Cause: the leading-whitespace skip and the specifier scanners hand `*data`/`*fmt` (a plain `char`) straight to `std::isspace`/`std::isdigit`. Where `char` is signed those bytes become negative ints, which is outside the ctype domain (unsigned char or EOF), so the call is UB — a debug MSVC CRT asserts and some libc builds index their classification table out of bounds.
Fix: cast each ctype argument to `unsigned char` at every call site in `parse()`/`format()` and the same construct in `time_tool.cc`. Valid input is unaffected; a leading 0xA0 is now consistently not treated as whitespace. Added a parse regression test covering non-ASCII input.