### PR TITLE
reject out-of-range transition times in TimeZoneInfo::Load

### DIFF
--- a/src/time_zone_info.cc
+++ b/src/time_zone_info.cc
@@ -692,8 +692,8 @@ bool TimeZoneInfo::Load(ZoneInfoSource* zip) {
     // A valid zoneinfo file keeps transition times far from the int64 limits.
     // A hostile one can place them at the extremes, where the reverse-conversion
     // arithmetic in MakeTime() (tr.unix_time +/- a sub-day civil delta, see
-    // MakeSkipped()/MakeRepeated()) overflows. Bound them to the -(1<<59)
-    // sentinel horizon used below.
+    // MakeSkipped()/MakeRepeated()) overflows. Bound them to +/-(1<<59), the
+    // times used by the no-op transitions added below.
     if (transitions_[i].unix_time < -(1LL << 59) ||
         transitions_[i].unix_time > (1LL << 59))
       return false;  // out of range

--- a/src/time_zone_info.cc
+++ b/src/time_zone_info.cc
@@ -689,6 +689,14 @@ bool TimeZoneInfo::Load(ZoneInfoSource* zip) {
   for (std::size_t i = 0; i != hdr.timecnt; ++i) {
     transitions_[i].unix_time = (time_len == 4) ? Decode32(bp) : Decode64(bp);
     bp += time_len;
+    // A valid zoneinfo file keeps transition times far from the int64 limits.
+    // A hostile one can place them at the extremes, where the reverse-conversion
+    // arithmetic in MakeTime() (tr.unix_time +/- a sub-day civil delta, see
+    // MakeSkipped()/MakeRepeated()) overflows. Bound them to the -(1<<59)
+    // sentinel horizon used below.
+    if (transitions_[i].unix_time < -(1LL << 59) ||
+        transitions_[i].unix_time > (1LL << 59))
+      return false;  // out of range
     if (i != 0) {
       // Check that the transitions are ordered by time (as zic guarantees).
       if (!Transition::ByUnixTime()(transitions_[i - 1], transitions_[i]))


### PR DESCRIPTION
A valid zoneinfo file keeps its transition times far from the int64 limits, but a crafted TZif blob can place one at the extremes. When that transition becomes the bounding transition during the reverse conversions in MakeTime(), MakeSkipped()/MakeRepeated() compute tr.unix_time - 1 and tr.unix_time +/- a sub-day civil delta, overflowing the signed 64-bit time (UBSan flags it at both ends, from a transition at INT64_MIN and one at INT64_MAX).

Bound the decoded transition times to +/-(1<<59), the times the loader already uses for the no-op transitions it adds, and reject anything outside. Real zoneinfo transitions live many orders of magnitude inside that range, so valid input is untouched, and checking at decode time keeps every downstream conversion representable without spreading guards across the lookup hot path.