### PR TITLE
Prevent load_time_zone() path traversal or arbitrary fopen

### DIFF
--- a/src/time_zone_info.cc
+++ b/src/time_zone_info.cc
@@ -385,11 +385,11 @@ namespace {
 
 using FilePtr = std::unique_ptr<FILE, int(*)(FILE*)>;
 
-// fopen(3) adaptor.
-inline FilePtr FOpen(const char* path, const char* mode) {
+// fopen(3) adaptor for reading zoneinfo files (read-only binary mode).
+inline FilePtr FOpen(const char* path) {
 #if defined(_MSC_VER)
   FILE* fp;
-  if (fopen_s(&fp, path, mode) != 0) fp = nullptr;
+  if (fopen_s(&fp, path, "rb") != 0) fp = nullptr;
   return FilePtr(fp, fclose);
 #else
   // Open non-blocking and verify the target is a regular file before handing it
@@ -397,20 +397,32 @@ inline FilePtr FOpen(const char* path, const char* mode) {
   // fopen() on a FIFO or device node (reachable via the "file:" prefix or an
   // absolute path) would block indefinitely or read unbounded data.
   const int fd = open(path, O_RDONLY | O_NONBLOCK | O_CLOEXEC);
-  if (fd < 0) {
-    return FilePtr(nullptr, fclose);
-  }
-  struct stat st;
-  if (fstat(fd, &st) != 0 || !S_ISREG(st.st_mode)) {
-    close(fd);
-    return FilePtr(nullptr, fclose);
-  }
-  FILE* fp = fdopen(fd, mode);
-  if (fp == nullptr) {
+  if (fd >= 0) {
+    struct stat st;
+    if (fstat(fd, &st) == 0 && S_ISREG(st.st_mode)) {
+      FILE* fp = fdopen(fd, "rb");
+      if (fp != nullptr) return FilePtr(fp, fclose);
+    }
     close(fd);
   }
-  return FilePtr(fp, fclose);
+  return FilePtr(nullptr, fclose);
 #endif
+}
+
+// Returns true if the zone name contains a ".." path-traversal component.
+inline bool HasPathTraversal(const std::string& name, std::size_t pos) {
+  // Exact match: ".."
+  if (name.compare(pos, std::string::npos, "..") == 0) return true;
+  // Leading component: "../"
+  if (name.compare(pos, 3, "../") == 0) return true;
+  // Interior component: "/../"
+  if (name.find("/../", pos) != std::string::npos) return true;
+  // Trailing component: "/.."
+  if (name.size() >= pos + 3 &&
+      name.compare(name.size() - 3, 3, "/..") == 0) {
+    return true;
+  }
+  return false;
 }
 
 // A stdio(3)-backed implementation of ZoneInfoSource.
@@ -452,7 +464,7 @@ std::unique_ptr<ZoneInfoSource> FileZoneInfoSource::Open(
 
   // Reject path-traversal components so that a relative zone name cannot
   // escape the zoneinfo directory (e.g., "../../etc/passwd").
-  if (name.find("..", pos) != std::string::npos) {
+  if (HasPathTraversal(name, pos)) {
     return nullptr;
   }
 
@@ -476,7 +488,7 @@ std::unique_ptr<ZoneInfoSource> FileZoneInfoSource::Open(
   path.append(name, pos, std::string::npos);
 
   // Open the zoneinfo file.
-  auto fp = FOpen(path.c_str(), "rb");
+  auto fp = FOpen(path.c_str());
   if (fp == nullptr) return nullptr;
   return std::unique_ptr<ZoneInfoSource>(new FileZoneInfoSource(std::move(fp)));
 }
@@ -502,7 +514,7 @@ std::unique_ptr<ZoneInfoSource> AndroidZoneInfoSource::Open(
   for (const char* tzdata : {"/apex/com.android.tzdata/etc/tz/tzdata",
                              "/data/misc/zoneinfo/current/tzdata",
                              "/system/usr/share/zoneinfo/tzdata"}) {
-    auto fp = FOpen(tzdata, "rb");
+    auto fp = FOpen(tzdata);
     if (fp == nullptr) continue;
 
     char hbuf[24];  // covers header.zonetab_offset too
@@ -585,7 +597,7 @@ std::unique_ptr<ZoneInfoSource> FuchsiaZoneInfoSource::Open(
     if (!prefix.empty()) path += "zoneinfo/tzif2/";  // format
     path.append(name, pos, std::string::npos);
 
-    auto fp = FOpen(path.c_str(), "rb");
+    auto fp = FOpen(path.c_str());
     if (fp == nullptr) continue;
 
     std::string version;

--- a/src/time_zone_info.cc
+++ b/src/time_zone_info.cc
@@ -409,16 +409,16 @@ inline FilePtr FOpen(const char* path) {
 #endif
 }
 
-// Returns true if the zone name contains a ".." path-traversal component.
-inline bool HasPathTraversal(const std::string& name, std::size_t pos) {
-  // Exact match: ".."
+// Returns true if the zone name starting at pos contains an unsafe path.
+inline bool UnsafePath(const std::string& name, std::size_t pos) {
+  // Path traversal: exact match ".."
   if (name.compare(pos, std::string::npos, "..") == 0) return true;
-  // Leading component: "../"
+  // Path traversal: leading component "../"
   if (name.compare(pos, 3, "../") == 0) return true;
-  // Interior component: "/../"
+  // Path traversal: interior component "/../"
   if (name.find("/../", pos) != std::string::npos) return true;
-  // Trailing component: "/.."
-  if (name.size() >= pos + 3 &&
+  // Path traversal: trailing component "/.."
+  if (name.size() - pos >= 3 &&
       name.compare(name.size() - 3, 3, "/..") == 0) {
     return true;
   }
@@ -462,9 +462,8 @@ std::unique_ptr<ZoneInfoSource> FileZoneInfoSource::Open(
   // Use of the "file:" prefix is intended for testing purposes only.
   const std::size_t pos = (name.compare(0, 5, "file:") == 0) ? 5 : 0;
 
-  // Reject path-traversal components so that a relative zone name cannot
-  // escape the zoneinfo directory (e.g., "../../etc/passwd").
-  if (HasPathTraversal(name, pos)) {
+  // Reject unsafe paths (e.g., "../../etc/passwd").
+  if (UnsafePath(name, pos)) {
     return nullptr;
   }
 

--- a/src/time_zone_info.cc
+++ b/src/time_zone_info.cc
@@ -32,6 +32,12 @@
 
 #include "time_zone_info.h"
 
+#if !defined(_MSC_VER)
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#endif
+
 #include <algorithm>
 #include <cassert>
 #include <chrono>
@@ -386,8 +392,24 @@ inline FilePtr FOpen(const char* path, const char* mode) {
   if (fopen_s(&fp, path, mode) != 0) fp = nullptr;
   return FilePtr(fp, fclose);
 #else
-  // TODO: Enable the close-on-exec flag.
-  return FilePtr(fopen(path, mode), fclose);
+  // Open non-blocking and verify the target is a regular file before handing it
+  // to stdio. Zone names are potentially attacker-controlled, and a plain
+  // fopen() on a FIFO or device node (reachable via the "file:" prefix or an
+  // absolute path) would block indefinitely or read unbounded data.
+  const int fd = open(path, O_RDONLY | O_NONBLOCK | O_CLOEXEC);
+  if (fd < 0) {
+    return FilePtr(nullptr, fclose);
+  }
+  struct stat st;
+  if (fstat(fd, &st) != 0 || !S_ISREG(st.st_mode)) {
+    close(fd);
+    return FilePtr(nullptr, fclose);
+  }
+  FILE* fp = fdopen(fd, mode);
+  if (fp == nullptr) {
+    close(fd);
+  }
+  return FilePtr(fp, fclose);
 #endif
 }
 
@@ -427,6 +449,12 @@ std::unique_ptr<ZoneInfoSource> FileZoneInfoSource::Open(
     const std::string& name) {
   // Use of the "file:" prefix is intended for testing purposes only.
   const std::size_t pos = (name.compare(0, 5, "file:") == 0) ? 5 : 0;
+
+  // Reject path-traversal components so that a relative zone name cannot
+  // escape the zoneinfo directory (e.g., "../../etc/passwd").
+  if (name.find("..", pos) != std::string::npos) {
+    return nullptr;
+  }
 
   // Map the time-zone name to a path name.
   std::string path;

--- a/src/time_zone_lookup_test.cc
+++ b/src/time_zone_lookup_test.cc
@@ -175,18 +175,14 @@ TEST(TimeZone, Failures) {
             convert(civil_second(1970, 1, 1, 0, 0, 0), tz));  // UTC
 
   // Reject path-traversal components.
-  tz = LoadZone("America/Los_Angeles");
   EXPECT_FALSE(load_time_zone("file:../etc/passwd", &tz));
   EXPECT_FALSE(load_time_zone("file:../../etc/passwd", &tz));
   EXPECT_FALSE(load_time_zone("file:/../etc/passwd", &tz));
+  EXPECT_FALSE(load_time_zone("file:America/../America/Los_Angeles", &tz));
 
-  // Reject non-regular files.
-  tz = LoadZone("America/Los_Angeles");
+  // Reject non-regular files and directories.
   EXPECT_FALSE(load_time_zone("file:/dev/null", &tz));
   EXPECT_FALSE(load_time_zone("file:/dev/stdin", &tz));
-
-  // Reject directories.
-  tz = LoadZone("America/Los_Angeles");
   EXPECT_FALSE(load_time_zone("file:/tmp", &tz));
 }
 

--- a/src/time_zone_lookup_test.cc
+++ b/src/time_zone_lookup_test.cc
@@ -173,6 +173,21 @@ TEST(TimeZone, Failures) {
   EXPECT_FALSE(load_time_zone("", &tz));
   EXPECT_EQ(chrono::system_clock::from_time_t(0),
             convert(civil_second(1970, 1, 1, 0, 0, 0), tz));  // UTC
+
+  // Reject path-traversal components.
+  tz = LoadZone("America/Los_Angeles");
+  EXPECT_FALSE(load_time_zone("file:../etc/passwd", &tz));
+  EXPECT_FALSE(load_time_zone("file:../../etc/passwd", &tz));
+  EXPECT_FALSE(load_time_zone("file:/../etc/passwd", &tz));
+
+  // Reject non-regular files.
+  tz = LoadZone("America/Los_Angeles");
+  EXPECT_FALSE(load_time_zone("file:/dev/null", &tz));
+  EXPECT_FALSE(load_time_zone("file:/dev/stdin", &tz));
+
+  // Reject directories.
+  tz = LoadZone("America/Los_Angeles");
+  EXPECT_FALSE(load_time_zone("file:/tmp", &tz));
 }
 
 TEST(TimeZone, Equality) {


### PR DESCRIPTION
FileZoneInfoSource::Open() strips an optional file: prefix and then concatenates the remainder of the zone-name string under TZDIR (or uses it verbatim if absolute) with no canonicalisation or ".." rejection, then calls fopen(path, "rb"). An attacker-controlled zone name like "../../../../../../tmp/evil" escapes TZDIR. "file:/dev/stdin" or any FIFO blocks the calling thread indefinitely.