### PR TITLE
Fix overflow/underflow detection in join_seconds

### DIFF
--- a/include/cctz/time_zone.h
+++ b/include/cctz/time_zone.h
@@ -404,9 +404,36 @@ bool join_seconds(
     const time_point<seconds>& sec, const femtoseconds& fs,
     time_point<std::chrono::duration<Rep, std::ratio<1, Denom>>>* tpp) {
   using D = std::chrono::duration<Rep, std::ratio<1, Denom>>;
-  // TODO(#199): Return false if result unrepresentable as a time_point<D>.
-  *tpp = std::chrono::time_point_cast<D>(sec);
-  *tpp += std::chrono::duration_cast<D>(fs);
+  // Use a 64-bit representation for intermediate subsecond calculations
+  // to avoid premature overflow if Rep is a smaller type (e.g., int8_t).
+  using D_check = std::chrono::duration<std::int64_t, std::ratio<1, Denom>>;
+  auto count = sec.time_since_epoch().count();
+  auto sub = std::chrono::duration_cast<D_check>(fs).count();  // [0, Denom)
+
+  // Check for overflow.
+  if (sub > (std::numeric_limits<Rep>::max)()) {
+    // If subseconds alone exceed the max representable value, any non-negative
+    // seconds count will cause overflow. Negative seconds might bring it back
+    // into range, which is handled by the underflow check below.
+    if (count >= 0) return false;
+  } else {
+    // Equivalent to: count * Denom + sub > max, but safe from overflow.
+    if (count > ((std::numeric_limits<Rep>::max)() - sub) / Denom) return false;
+  }
+
+  // Check for underflow.
+  // Equivalent to: count * Denom + sub < min, but safe from underflow.
+  // We cannot use "min - sub" directly as it would underflow.
+  const auto min_div = (std::numeric_limits<Rep>::min)() / Denom;
+  if (count < min_div) {
+    // If count is less than min_div - 1, it's definitely underflow.
+    if (count < min_div - 1) return false;
+    // If count is exactly min_div - 1, we must check if subseconds are
+    // sufficient to bring the total value back above min.
+    const auto min_mod = (std::numeric_limits<Rep>::min)() % Denom;
+    if (sub < Denom + min_mod) return false;
+  }
+  *tpp = time_point<D>() + D{static_cast<Rep>(count * Denom + sub)};
   return true;
 }
 

--- a/include/cctz/time_zone.h
+++ b/include/cctz/time_zone.h
@@ -25,6 +25,7 @@
 #include <limits>
 #include <ratio>
 #include <string>
+#include <type_traits>
 #include <utility>
 
 #include "cctz/civil_time.h"
@@ -402,13 +403,13 @@ inline std::pair<time_point<seconds>, seconds> split_seconds(
 template <typename Rep, std::intmax_t Denom>
 bool join_seconds(
     const time_point<seconds>& sec, const femtoseconds& fs,
-    time_point<std::chrono::duration<Rep, std::ratio<1, Denom>>>* tpp) {
+    time_point<std::chrono::duration<Rep, std::ratio<1, Denom>>>* tpp,
+    std::true_type /* is_integral */) {
   using D = std::chrono::duration<Rep, std::ratio<1, Denom>>;
-  // Use a 64-bit representation for intermediate subsecond calculations
-  // to avoid premature overflow if Rep is a smaller type (e.g., int8_t).
-  using D_check = std::chrono::duration<std::int64_t, std::ratio<1, Denom>>;
-  auto count = sec.time_since_epoch().count();
-  auto sub = std::chrono::duration_cast<D_check>(fs).count();  // [0, Denom)
+  using D_check = std::chrono::duration<std::intmax_t, std::ratio<1, Denom>>;
+  const auto count = static_cast<std::intmax_t>(sec.time_since_epoch().count());
+  const auto sub =
+      std::chrono::duration_cast<D_check>(fs).count();  // [0, Denom)
 
   // Check for overflow.
   if (sub > (std::numeric_limits<Rep>::max)()) {
@@ -422,19 +423,40 @@ bool join_seconds(
   }
 
   // Check for underflow.
-  // Equivalent to: count * Denom + sub < min, but safe from underflow.
-  // We cannot use "min - sub" directly as it would underflow.
-  const auto min_div = (std::numeric_limits<Rep>::min)() / Denom;
+  // Equivalent to: count * Denom + sub < lowest, but safe from underflow.
+  // We cannot use "lowest - sub" directly as it would underflow.
+  const auto min_div = (std::numeric_limits<Rep>::lowest)() / Denom;
   if (count < min_div) {
     // If count is less than min_div - 1, it's definitely underflow.
     if (count < min_div - 1) return false;
     // If count is exactly min_div - 1, we must check if subseconds are
-    // sufficient to bring the total value back above min.
-    const auto min_mod = (std::numeric_limits<Rep>::min)() % Denom;
+    // sufficient to bring the total value back above lowest.
+    const auto min_mod = (std::numeric_limits<Rep>::lowest)() % Denom;
     if (sub < Denom + min_mod) return false;
+    *tpp =
+        time_point<D>() + D{static_cast<Rep>(min_div * Denom + (sub - Denom))};
+    return true;
   }
   *tpp = time_point<D>() + D{static_cast<Rep>(count * Denom + sub)};
   return true;
+}
+
+template <typename Rep, std::intmax_t Denom>
+bool join_seconds(
+    const time_point<seconds>& sec, const femtoseconds& fs,
+    time_point<std::chrono::duration<Rep, std::ratio<1, Denom>>>* tpp,
+    std::false_type /* is_integral */) {
+  using D = std::chrono::duration<Rep, std::ratio<1, Denom>>;
+  *tpp = std::chrono::time_point_cast<D>(sec);
+  *tpp += std::chrono::duration_cast<D>(fs);
+  return true;
+}
+
+template <typename Rep, std::intmax_t Denom>
+bool join_seconds(
+    const time_point<seconds>& sec, const femtoseconds& fs,
+    time_point<std::chrono::duration<Rep, std::ratio<1, Denom>>>* tpp) {
+  return join_seconds(sec, fs, tpp, std::is_integral<Rep>());
 }
 
 template <typename Rep, std::intmax_t Num>
@@ -450,7 +472,8 @@ bool join_seconds(
     count -= 1;
   }
   if (count > (std::numeric_limits<Rep>::max)()) return false;
-  if (count < (std::numeric_limits<Rep>::min)()) return false;
+  if (count < (std::numeric_limits<Rep>::lowest)())
+    return false;
   *tpp = time_point<D>() + D{static_cast<Rep>(count)};
   return true;
 }
@@ -462,7 +485,8 @@ bool join_seconds(
   using D = std::chrono::duration<Rep, std::ratio<1, 1>>;
   auto count = sec.time_since_epoch().count();
   if (count > (std::numeric_limits<Rep>::max)()) return false;
-  if (count < (std::numeric_limits<Rep>::min)()) return false;
+  if (count < (std::numeric_limits<Rep>::lowest)())
+    return false;
   *tpp = time_point<D>() + D{static_cast<Rep>(count)};
   return true;
 }

--- a/include/cctz/time_zone.h
+++ b/include/cctz/time_zone.h
@@ -396,12 +396,8 @@ namespace detail {
 template <typename D>
 std::pair<time_point<seconds>, D> split_seconds(const time_point<D>& tp) {
   auto sec = std::chrono::time_point_cast<seconds>(tp);
-  auto sub = tp - sec;
-  if (sub < D::zero()) {
-    sec -= seconds(1);
-    sub += seconds(1);
-  }
-  return {sec, std::chrono::duration_cast<D>(sub)};
+  if (sec > tp) sec -= seconds{1};  // TODO(C++17): use std::chrono::floor
+  return {sec, std::chrono::duration_cast<D>(tp - sec)};
 }
 
 inline std::pair<time_point<seconds>, seconds> split_seconds(
@@ -492,7 +488,7 @@ join_seconds(
   auto count = sec.time_since_epoch().count();
   if (count > (std::numeric_limits<Rep>::max)()) return false;
   if (count < (std::numeric_limits<Rep>::lowest)()) return false;
-  *tpp = std::chrono::time_point_cast<D>(sec);
+  *tpp = time_point<D>() + D{static_cast<Rep>(count)};
   return true;
 }
 

--- a/include/cctz/time_zone.h
+++ b/include/cctz/time_zone.h
@@ -472,8 +472,7 @@ bool join_seconds(
     count -= 1;
   }
   if (count > (std::numeric_limits<Rep>::max)()) return false;
-  if (count < (std::numeric_limits<Rep>::lowest)())
-    return false;
+  if (count < (std::numeric_limits<Rep>::lowest)()) return false;
   *tpp = time_point<D>() + D{static_cast<Rep>(count)};
   return true;
 }
@@ -485,8 +484,7 @@ bool join_seconds(
   using D = std::chrono::duration<Rep, std::ratio<1, 1>>;
   auto count = sec.time_since_epoch().count();
   if (count > (std::numeric_limits<Rep>::max)()) return false;
-  if (count < (std::numeric_limits<Rep>::lowest)())
-    return false;
+  if (count < (std::numeric_limits<Rep>::lowest)()) return false;
   *tpp = time_point<D>() + D{static_cast<Rep>(count)};
   return true;
 }

--- a/include/cctz/time_zone.h
+++ b/include/cctz/time_zone.h
@@ -267,15 +267,20 @@ std::string format(const std::string&, const time_point<seconds>&,
 bool parse(const std::string&, const std::string&, const time_zone&,
            time_point<seconds>*, femtoseconds*, std::string* err = nullptr);
 template <typename Rep, std::intmax_t Denom>
-bool join_seconds(
+typename std::enable_if<std::is_integral<Rep>::value, bool>::type join_seconds(
     const time_point<seconds>& sec, const femtoseconds& fs,
     time_point<std::chrono::duration<Rep, std::ratio<1, Denom>>>* tpp);
+template <typename Rep, std::intmax_t Num, std::intmax_t Denom>
+typename std::enable_if<std::is_floating_point<Rep>::value, bool>::type
+join_seconds(
+    const time_point<seconds>& sec, const femtoseconds& fs,
+    time_point<std::chrono::duration<Rep, std::ratio<Num, Denom>>>* tpp);
 template <typename Rep, std::intmax_t Num>
-bool join_seconds(
+typename std::enable_if<std::is_integral<Rep>::value, bool>::type join_seconds(
     const time_point<seconds>& sec, const femtoseconds& fs,
     time_point<std::chrono::duration<Rep, std::ratio<Num, 1>>>* tpp);
 template <typename Rep>
-bool join_seconds(
+typename std::enable_if<std::is_integral<Rep>::value, bool>::type join_seconds(
     const time_point<seconds>& sec, const femtoseconds& fs,
     time_point<std::chrono::duration<Rep, std::ratio<1, 1>>>* tpp);
 bool join_seconds(const time_point<seconds>& sec, const femtoseconds&,
@@ -365,13 +370,17 @@ inline std::string format(const std::string& fmt, const time_point<D>& tp,
 //   if (cctz::parse("%Y-%m-%d", "2015-10-09", tz, &tp)) {
 //     ...
 //   }
-template <typename D>
+template <typename Rep, typename Period>
 inline bool parse(const std::string& fmt, const std::string& input,
-                  const time_zone& tz, time_point<D>* tpp) {
+                  const time_zone& tz,
+                  time_point<std::chrono::duration<Rep, Period>>* tpp) {
   time_point<seconds> sec;
   detail::femtoseconds fs;
-  return detail::parse(fmt, input, tz, &sec, &fs) &&
-         detail::join_seconds(sec, fs, tpp);
+  if (!detail::parse(fmt, input, tz, &sec, &fs)) return false;
+  time_point<std::chrono::duration<Rep, typename Period::type>> tp;
+  if (!detail::join_seconds(sec, fs, &tp)) return false;
+  *tpp = tp;
+  return true;
 }
 
 namespace detail {
@@ -401,13 +410,12 @@ inline std::pair<time_point<seconds>, seconds> split_seconds(
 // Floors to the resolution of time_point<D>. Returns false if time_point<D>
 // is not of sufficient range.
 template <typename Rep, std::intmax_t Denom>
-bool join_seconds(
+typename std::enable_if<std::is_integral<Rep>::value, bool>::type join_seconds(
     const time_point<seconds>& sec, const femtoseconds& fs,
-    time_point<std::chrono::duration<Rep, std::ratio<1, Denom>>>* tpp,
-    std::true_type /* is_integral */) {
+    time_point<std::chrono::duration<Rep, std::ratio<1, Denom>>>* tpp) {
   using D = std::chrono::duration<Rep, std::ratio<1, Denom>>;
   using D_check = std::chrono::duration<std::intmax_t, std::ratio<1, Denom>>;
-  const auto count = static_cast<std::intmax_t>(sec.time_since_epoch().count());
+  const std::intmax_t count = sec.time_since_epoch().count();
   const auto sub =
       std::chrono::duration_cast<D_check>(fs).count();  // [0, Denom)
 
@@ -441,26 +449,19 @@ bool join_seconds(
   return true;
 }
 
-template <typename Rep, std::intmax_t Denom>
-bool join_seconds(
+template <typename Rep, std::intmax_t Num, std::intmax_t Denom>
+typename std::enable_if<std::is_floating_point<Rep>::value, bool>::type
+join_seconds(
     const time_point<seconds>& sec, const femtoseconds& fs,
-    time_point<std::chrono::duration<Rep, std::ratio<1, Denom>>>* tpp,
-    std::false_type /* is_integral */) {
-  using D = std::chrono::duration<Rep, std::ratio<1, Denom>>;
+    time_point<std::chrono::duration<Rep, std::ratio<Num, Denom>>>* tpp) {
+  using D = std::chrono::duration<Rep, std::ratio<Num, Denom>>;
   *tpp = std::chrono::time_point_cast<D>(sec);
   *tpp += std::chrono::duration_cast<D>(fs);
   return true;
 }
 
-template <typename Rep, std::intmax_t Denom>
-bool join_seconds(
-    const time_point<seconds>& sec, const femtoseconds& fs,
-    time_point<std::chrono::duration<Rep, std::ratio<1, Denom>>>* tpp) {
-  return join_seconds(sec, fs, tpp, std::is_integral<Rep>());
-}
-
 template <typename Rep, std::intmax_t Num>
-bool join_seconds(
+typename std::enable_if<std::is_integral<Rep>::value, bool>::type join_seconds(
     const time_point<seconds>& sec, const femtoseconds&,
     time_point<std::chrono::duration<Rep, std::ratio<Num, 1>>>* tpp) {
   using D = std::chrono::duration<Rep, std::ratio<Num, 1>>;
@@ -478,14 +479,14 @@ bool join_seconds(
 }
 
 template <typename Rep>
-bool join_seconds(
+typename std::enable_if<std::is_integral<Rep>::value, bool>::type join_seconds(
     const time_point<seconds>& sec, const femtoseconds&,
     time_point<std::chrono::duration<Rep, std::ratio<1, 1>>>* tpp) {
   using D = std::chrono::duration<Rep, std::ratio<1, 1>>;
   auto count = sec.time_since_epoch().count();
   if (count > (std::numeric_limits<Rep>::max)()) return false;
   if (count < (std::numeric_limits<Rep>::lowest)()) return false;
-  *tpp = time_point<D>() + D{static_cast<Rep>(count)};
+  *tpp = std::chrono::time_point_cast<D>(sec);
   return true;
 }
 

--- a/include/cctz/time_zone.h
+++ b/include/cctz/time_zone.h
@@ -267,7 +267,8 @@ std::string format(const std::string&, const time_point<seconds>&,
 bool parse(const std::string&, const std::string&, const time_zone&,
            time_point<seconds>*, femtoseconds*, std::string* err = nullptr);
 template <typename Rep, std::intmax_t Denom>
-typename std::enable_if<std::is_integral<Rep>::value, bool>::type join_seconds(
+typename std::enable_if<std::is_integral<Rep>::value, bool>::type
+join_seconds(
     const time_point<seconds>& sec, const femtoseconds& fs,
     time_point<std::chrono::duration<Rep, std::ratio<1, Denom>>>* tpp);
 template <typename Rep, std::intmax_t Num, std::intmax_t Denom>
@@ -276,11 +277,13 @@ join_seconds(
     const time_point<seconds>& sec, const femtoseconds& fs,
     time_point<std::chrono::duration<Rep, std::ratio<Num, Denom>>>* tpp);
 template <typename Rep, std::intmax_t Num>
-typename std::enable_if<std::is_integral<Rep>::value, bool>::type join_seconds(
+typename std::enable_if<std::is_integral<Rep>::value, bool>::type
+join_seconds(
     const time_point<seconds>& sec, const femtoseconds& fs,
     time_point<std::chrono::duration<Rep, std::ratio<Num, 1>>>* tpp);
 template <typename Rep>
-typename std::enable_if<std::is_integral<Rep>::value, bool>::type join_seconds(
+typename std::enable_if<std::is_integral<Rep>::value, bool>::type
+join_seconds(
     const time_point<seconds>& sec, const femtoseconds& fs,
     time_point<std::chrono::duration<Rep, std::ratio<1, 1>>>* tpp);
 bool join_seconds(const time_point<seconds>& sec, const femtoseconds&,
@@ -371,9 +374,9 @@ inline std::string format(const std::string& fmt, const time_point<D>& tp,
 //     ...
 //   }
 template <typename Rep, typename Period>
-inline bool parse(const std::string& fmt, const std::string& input,
-                  const time_zone& tz,
-                  time_point<std::chrono::duration<Rep, Period>>* tpp) {
+bool parse(const std::string& fmt, const std::string& input,
+           const time_zone& tz,
+           time_point<std::chrono::duration<Rep, Period>>* tpp) {
   time_point<seconds> sec;
   detail::femtoseconds fs;
   if (!detail::parse(fmt, input, tz, &sec, &fs)) return false;
@@ -394,7 +397,7 @@ template <typename D>
 std::pair<time_point<seconds>, D> split_seconds(const time_point<D>& tp) {
   auto sec = std::chrono::time_point_cast<seconds>(tp);
   auto sub = tp - sec;
-  if (sub.count() < 0) {
+  if (sub < D::zero()) {
     sec -= seconds(1);
     sub += seconds(1);
   }
@@ -410,7 +413,8 @@ inline std::pair<time_point<seconds>, seconds> split_seconds(
 // Floors to the resolution of time_point<D>. Returns false if time_point<D>
 // is not of sufficient range.
 template <typename Rep, std::intmax_t Denom>
-typename std::enable_if<std::is_integral<Rep>::value, bool>::type join_seconds(
+typename std::enable_if<std::is_integral<Rep>::value, bool>::type
+join_seconds(
     const time_point<seconds>& sec, const femtoseconds& fs,
     time_point<std::chrono::duration<Rep, std::ratio<1, Denom>>>* tpp) {
   using D = std::chrono::duration<Rep, std::ratio<1, Denom>>;
@@ -461,7 +465,8 @@ join_seconds(
 }
 
 template <typename Rep, std::intmax_t Num>
-typename std::enable_if<std::is_integral<Rep>::value, bool>::type join_seconds(
+typename std::enable_if<std::is_integral<Rep>::value, bool>::type
+join_seconds(
     const time_point<seconds>& sec, const femtoseconds&,
     time_point<std::chrono::duration<Rep, std::ratio<Num, 1>>>* tpp) {
   using D = std::chrono::duration<Rep, std::ratio<Num, 1>>;
@@ -479,7 +484,8 @@ typename std::enable_if<std::is_integral<Rep>::value, bool>::type join_seconds(
 }
 
 template <typename Rep>
-typename std::enable_if<std::is_integral<Rep>::value, bool>::type join_seconds(
+typename std::enable_if<std::is_integral<Rep>::value, bool>::type
+join_seconds(
     const time_point<seconds>& sec, const femtoseconds&,
     time_point<std::chrono::duration<Rep, std::ratio<1, 1>>>* tpp) {
   using D = std::chrono::duration<Rep, std::ratio<1, 1>>;

--- a/include/cctz/time_zone.h
+++ b/include/cctz/time_zone.h
@@ -380,8 +380,10 @@ bool parse(const std::string& fmt, const std::string& input,
   time_point<seconds> sec;
   detail::femtoseconds fs;
   if (!detail::parse(fmt, input, tz, &sec, &fs)) return false;
+
   time_point<std::chrono::duration<Rep, typename Period::type>> tp;
   if (!detail::join_seconds(sec, fs, &tp)) return false;
+
   *tpp = tp;
   return true;
 }

--- a/src/time_zone_format.cc
+++ b/src/time_zone_format.cc
@@ -33,6 +33,7 @@
 // declare strptime.
 #include <time.h>
 
+#include <cassert>
 #include <cctype>
 #include <chrono>
 #include <cstddef>
@@ -703,6 +704,14 @@ bool FromWeek(int week_num, weekday week_start, year_t* year, std::tm* tm) {
 bool parse(const std::string& format, const std::string& input,
            const time_zone& tz, time_point<seconds>* sec,
            detail::femtoseconds* fs, std::string* err) {
+#if __cplusplus < 202002L
+  // Assert that the std::chrono::system_clock epoch is the Unix epoch.
+  // This is required by C++20, but was also ubiquitous before that.
+  // We use this in join_seconds() to simplify overflow detection.
+  assert(std::chrono::system_clock::from_time_t(0).time_since_epoch() ==
+         std::chrono::system_clock::duration::zero());
+#endif
+
   // The unparsed input.  Even though we allow NULs in input, and
   // match them against corresponding NULs in format, we depend on
   // *edata being a NUL so that we can call strptime().  This also

--- a/src/time_zone_format_test.cc
+++ b/src/time_zone_format_test.cc
@@ -1613,52 +1613,84 @@ TEST(Parse, MaxRange) {
 TEST(Parse, TimePointOverflow) {
   const time_zone utc = utc_time_zone();
 
+  // Test with nanosecond resolution (typical 64-bit time_point).
   using D = chrono::duration<std::int64_t, std::nano>;
   time_point<D> tp;
 
+  // Max representable time_point<D> is 2262-04-11T23:47:16.854775807 UTC.
   EXPECT_TRUE(
       parse(RFC3339_full, "2262-04-11T23:47:16.8547758079+00:00", utc, &tp));
   EXPECT_EQ(tp, time_point<D>::max());
   EXPECT_EQ("2262-04-11T23:47:16.854775807+00:00",
             cctz::format(RFC3339_full, tp, utc));
-#if 0
-  // TODO(#199): Will fail until cctz::parse() properly detects overflow.
+  
+  // 1 nanosecond beyond max should fail.
   EXPECT_FALSE(
       parse(RFC3339_full, "2262-04-11T23:47:16.8547758080+00:00", utc, &tp));
+
+  // Min representable time_point<D> is 1677-09-21T00:12:43.145224192 UTC.
   EXPECT_TRUE(
       parse(RFC3339_full, "1677-09-21T00:12:43.1452241920+00:00", utc, &tp));
   EXPECT_EQ(tp, time_point<D>::min());
   EXPECT_EQ("1677-09-21T00:12:43.145224192+00:00",
             cctz::format(RFC3339_full, tp, utc));
+
+  // 1 nanosecond below min should fail.
   EXPECT_FALSE(
       parse(RFC3339_full, "1677-09-21T00:12:43.1452241919+00:00", utc, &tp));
-#endif
 
+  // Test with 1-second resolution using int8_t (very narrow range: [-128, 127] seconds).
   using DS = chrono::duration<std::int8_t, chrono::seconds::period>;
   time_point<DS> stp;
 
+  // Max: 127 seconds.
   EXPECT_TRUE(parse(RFC3339_full, "1970-01-01T00:02:07.9+00:00", utc, &stp));
   EXPECT_EQ(stp, time_point<DS>::max());
   EXPECT_EQ("1970-01-01T00:02:07+00:00", cctz::format(RFC3339_full, stp, utc));
+  // 128 seconds should fail.
   EXPECT_FALSE(parse(RFC3339_full, "1970-01-01T00:02:08+00:00", utc, &stp));
 
+  // Min: -128 seconds.
   EXPECT_TRUE(parse(RFC3339_full, "1969-12-31T23:57:52+00:00", utc, &stp));
   EXPECT_EQ(stp, time_point<DS>::min());
   EXPECT_EQ("1969-12-31T23:57:52+00:00", cctz::format(RFC3339_full, stp, utc));
+  // -129 seconds should fail.
   EXPECT_FALSE(parse(RFC3339_full, "1969-12-31T23:57:51.9+00:00", utc, &stp));
 
+  // Test with 1-minute resolution using int8_t (range: [-128, 127] minutes).
   using DM = chrono::duration<std::int8_t, chrono::minutes::period>;
   time_point<DM> mtp;
 
+  // Max: 127 minutes (02:07).
   EXPECT_TRUE(parse(RFC3339_full, "1970-01-01T02:07:59+00:00", utc, &mtp));
   EXPECT_EQ(mtp, time_point<DM>::max());
   EXPECT_EQ("1970-01-01T02:07:00+00:00", cctz::format(RFC3339_full, mtp, utc));
+  // 128 minutes (02:08) should fail.
   EXPECT_FALSE(parse(RFC3339_full, "1970-01-01T02:08:00+00:00", utc, &mtp));
 
+  // Min: -128 minutes (21:52).
   EXPECT_TRUE(parse(RFC3339_full, "1969-12-31T21:52:00+00:00", utc, &mtp));
   EXPECT_EQ(mtp, time_point<DM>::min());
   EXPECT_EQ("1969-12-31T21:52:00+00:00", cctz::format(RFC3339_full, mtp, utc));
+  // -129 minutes (21:51:59) should fail.
   EXPECT_FALSE(parse(RFC3339_full, "1969-12-31T21:51:59+00:00", utc, &mtp));
+
+  // Test with millisecond resolution using int8_t (range: [-128, 127] milliseconds).
+  // This tests the case where Denom (1000) is larger than Rep max/min (127/-128).
+  using D_milli_int8 = chrono::duration<std::int8_t, std::milli>;
+  time_point<D_milli_int8> milli_stp;
+
+  // Max: 127 milliseconds.
+  EXPECT_TRUE(parse(RFC3339_full, "1970-01-01T00:00:00.127+00:00", utc, &milli_stp));
+  EXPECT_EQ(milli_stp.time_since_epoch().count(), 127);
+  // 128 milliseconds should fail (tests sub > max check).
+  EXPECT_FALSE(parse(RFC3339_full, "1970-01-01T00:00:00.128+00:00", utc, &milli_stp));
+
+  // Min: -128 milliseconds (1969-12-31T23:59:59.872 is -128ms).
+  EXPECT_TRUE(parse(RFC3339_full, "1969-12-31T23:59:59.872+00:00", utc, &milli_stp));
+  EXPECT_EQ(milli_stp.time_since_epoch().count(), -128);
+  // -129 milliseconds should fail (tests min boundary with Denom > -min).
+  EXPECT_FALSE(parse(RFC3339_full, "1969-12-31T23:59:59.871+00:00", utc, &milli_stp));
 }
 
 TEST(Parse, TimePointOverflowFloor) {

--- a/src/time_zone_format_test.cc
+++ b/src/time_zone_format_test.cc
@@ -788,10 +788,14 @@ TEST(Parse, TimePointResolution) {
   time_point<chrono::minutes> tp_m;
   EXPECT_TRUE(parse(kFmt, "03:04:05", utc, &tp_m));
   EXPECT_EQ("03:04:00", cctz::format(kFmt, tp_m, utc));
+  EXPECT_TRUE(parse(RFC3339_full, "1969-12-31T23:59:05+00:00", utc, &tp_m));
+  EXPECT_EQ("1969-12-31T23:59:00+00:00", cctz::format(RFC3339_full, tp_m, utc));
 
   time_point<chrono::hours> tp_h;
   EXPECT_TRUE(parse(kFmt, "03:04:05", utc, &tp_h));
   EXPECT_EQ("03:00:00", cctz::format(kFmt, tp_h, utc));
+  EXPECT_TRUE(parse(RFC3339_full, "1969-12-31T23:59:05+00:00", utc, &tp_h));
+  EXPECT_EQ("1969-12-31T23:00:00+00:00", cctz::format(RFC3339_full, tp_h, utc));
 }
 
 TEST(Parse, TimePointExtendedResolution) {

--- a/src/time_zone_format_test.cc
+++ b/src/time_zone_format_test.cc
@@ -1638,7 +1638,7 @@ TEST(Parse, TimePointOverflow) {
   EXPECT_EQ(tp, time_point<D>::max());
   EXPECT_EQ("2262-04-11T23:47:16.854775807+00:00",
             cctz::format(RFC3339_full, tp, utc));
-  
+
   // 1 nanosecond beyond max should fail.
   EXPECT_FALSE(
       parse(RFC3339_full, "2262-04-11T23:47:16.8547758080+00:00", utc, &tp));
@@ -1653,6 +1653,49 @@ TEST(Parse, TimePointOverflow) {
   // 1 nanosecond below min should fail.
   EXPECT_FALSE(
       parse(RFC3339_full, "1677-09-21T00:12:43.1452241919+00:00", utc, &tp));
+
+  // Test with femtosecond resolution.
+  using DF = chrono::duration<std::int64_t, std::femto>;
+  time_point<DF> ftp;
+
+  // Max representable time_point<DF> is 1970-01-01T02:33:43.372036854775807
+  // UTC.
+  EXPECT_TRUE(parse(RFC3339_full, "1970-01-01T02:33:43.3720368547758079+00:00",
+                    utc, &ftp));
+  EXPECT_EQ(ftp, time_point<DF>::max());
+  EXPECT_EQ("1970-01-01T02:33:43.372036854775807+00:00",
+            cctz::format(RFC3339_full, ftp, utc));
+  // 1 femtosecond beyond max should fail.
+  EXPECT_FALSE(parse(RFC3339_full, "1970-01-01T02:33:43.3720368547758080+00:00",
+                     utc, &ftp));
+
+  // Min representable time_point<DF> is 1969-12-31T21:26:16.627963145224192
+  // UTC.
+  EXPECT_TRUE(parse(RFC3339_full, "1969-12-31T21:26:16.6279631452241920+00:00",
+                    utc, &ftp));
+  EXPECT_EQ(ftp, time_point<DF>::min());
+  EXPECT_EQ("1969-12-31T21:26:16.627963145224192+00:00",
+            cctz::format(RFC3339_full, ftp, utc));
+  // 1 femtosecond below min should fail.
+  EXPECT_FALSE(parse(RFC3339_full, "1969-12-31T21:26:16.6279631452241919+00:00",
+                     utc, &ftp));
+
+  // Test with attosecond resolution.
+  using DA = chrono::duration<std::int64_t, std::atto>;
+  time_point<DA> atp;
+
+  // 9 seconds fits in 64-bit attoseconds.
+  EXPECT_TRUE(parse(RFC3339_full, "1970-01-01T00:00:09.223372036854775+00:00",
+                    utc, &atp));
+  EXPECT_EQ(atp.time_since_epoch().count(), 9223372036854775000LL);
+  // 10 seconds exceeds 64-bit attoseconds limit.
+  EXPECT_FALSE(parse(RFC3339_full, "1970-01-01T00:00:10+00:00", utc, &atp));
+
+  // -9 seconds fits in 64-bit attoseconds.
+  EXPECT_TRUE(parse(RFC3339_full, "1969-12-31T23:59:51+00:00", utc, &atp));
+  EXPECT_EQ(atp.time_since_epoch().count(), -9000000000000000000LL);
+  // -10 seconds underflows 64-bit attoseconds limit.
+  EXPECT_FALSE(parse(RFC3339_full, "1969-12-31T23:59:50+00:00", utc, &atp));
 
   // Test with 1-second resolution using int8_t (very narrow range: [-128, 127] seconds).
   using DS = chrono::duration<std::int8_t, chrono::seconds::period>;
@@ -1706,6 +1749,23 @@ TEST(Parse, TimePointOverflow) {
   EXPECT_EQ(milli_stp.time_since_epoch().count(), -128);
   // -129 milliseconds should fail (tests min boundary with Denom > -min).
   EXPECT_FALSE(parse(RFC3339_full, "1969-12-31T23:59:59.871+00:00", utc, &milli_stp));
+
+  // Test with floating-point representation.
+  using DD = chrono::duration<double>;
+  time_point<DD> dtp;
+
+  EXPECT_TRUE(parse(RFC3339_full, "1970-01-01T00:00:01+00:00", utc, &dtp));
+  EXPECT_EQ(dtp.time_since_epoch().count(), 1.0);
+  EXPECT_TRUE(parse(RFC3339_full, "1969-12-31T23:59:59+00:00", utc, &dtp));
+  EXPECT_EQ(dtp.time_since_epoch().count(), -1.0);
+
+  using DD_milli = chrono::duration<double, std::milli>;
+  time_point<DD_milli> mdtp;
+
+  EXPECT_TRUE(parse(RFC3339_full, "1970-01-01T00:00:00.5+00:00", utc, &mdtp));
+  EXPECT_EQ(mdtp.time_since_epoch().count(), 500.0);
+  EXPECT_TRUE(parse(RFC3339_full, "1969-12-31T23:59:59.5+00:00", utc, &mdtp));
+  EXPECT_EQ(mdtp.time_since_epoch().count(), -500.0);
 }
 
 TEST(Parse, TimePointOverflowFloor) {
@@ -1719,8 +1779,6 @@ TEST(Parse, TimePointOverflowFloor) {
   EXPECT_EQ(tp, time_point<D>::max());
   EXPECT_EQ("294247-01-10T04:00:54.775807+00:00",
             cctz::format(RFC3339_full, tp, utc));
-#if 0
-  // TODO(#199): Will fail until cctz::parse() properly detects overflow.
   EXPECT_FALSE(
       parse(RFC3339_full, "294247-01-10T04:00:54.7758080+00:00", utc, &tp));
   EXPECT_TRUE(
@@ -1730,7 +1788,6 @@ TEST(Parse, TimePointOverflowFloor) {
             cctz::format(RFC3339_full, tp, utc));
   EXPECT_FALSE(
       parse(RFC3339_full, "-290308-12-21T19:59:05.2241919+00:00", utc, &tp));
-#endif
 }
 
 //

--- a/src/time_zone_format_test.cc
+++ b/src/time_zone_format_test.cc
@@ -788,12 +788,16 @@ TEST(Parse, TimePointResolution) {
   time_point<chrono::minutes> tp_m;
   EXPECT_TRUE(parse(kFmt, "03:04:05", utc, &tp_m));
   EXPECT_EQ("03:04:00", cctz::format(kFmt, tp_m, utc));
+
+  // Verify that pre-epoch times floor towards negative infinity.
   EXPECT_TRUE(parse(RFC3339_full, "1969-12-31T23:59:05+00:00", utc, &tp_m));
   EXPECT_EQ("1969-12-31T23:59:00+00:00", cctz::format(RFC3339_full, tp_m, utc));
 
   time_point<chrono::hours> tp_h;
   EXPECT_TRUE(parse(kFmt, "03:04:05", utc, &tp_h));
   EXPECT_EQ("03:00:00", cctz::format(kFmt, tp_h, utc));
+
+  // Verify that pre-epoch times floor towards negative infinity.
   EXPECT_TRUE(parse(RFC3339_full, "1969-12-31T23:59:05+00:00", utc, &tp_h));
   EXPECT_EQ("1969-12-31T23:00:00+00:00", cctz::format(RFC3339_full, tp_h, utc));
 }

--- a/src/time_zone_format_test.cc
+++ b/src/time_zone_format_test.cc
@@ -17,6 +17,7 @@
 #include <chrono>
 #include <cstdint>
 #include <iomanip>
+#include <ratio>
 #include <sstream>
 #include <string>
 #if defined(__linux__)
@@ -1627,145 +1628,189 @@ TEST(Parse, MaxRange) {
 
 TEST(Parse, TimePointOverflow) {
   const time_zone utc = utc_time_zone();
+  {
+    // Test with nanosecond resolution (typical 64-bit time_point).
+    using D = chrono::duration<std::int64_t, std::nano>;
+    time_point<D> tp;
 
-  // Test with nanosecond resolution (typical 64-bit time_point).
-  using D = chrono::duration<std::int64_t, std::nano>;
+    // Max time_point<D> is 2262-04-11T23:47:16.854775807+00:00.
+    EXPECT_TRUE(
+        parse(RFC3339_full, "2262-04-11T23:47:16.8547758079+00:00", utc, &tp));
+    EXPECT_EQ(tp, time_point<D>::max());
+    EXPECT_EQ("2262-04-11T23:47:16.854775807+00:00",
+              cctz::format(RFC3339_full, tp, utc));
+    // 1 nanosecond beyond max should fail.
+    EXPECT_FALSE(
+        parse(RFC3339_full, "2262-04-11T23:47:16.8547758080+00:00", utc, &tp));
+
+    // Min time_point<D> is 1677-09-21T00:12:43.145224192+00:00.
+    EXPECT_TRUE(
+        parse(RFC3339_full, "1677-09-21T00:12:43.1452241920+00:00", utc, &tp));
+    EXPECT_EQ(tp, time_point<D>::min());
+    EXPECT_EQ("1677-09-21T00:12:43.145224192+00:00",
+              cctz::format(RFC3339_full, tp, utc));
+    // 1 nanosecond below min should fail.
+    EXPECT_FALSE(
+        parse(RFC3339_full, "1677-09-21T00:12:43.1452241919+00:00", utc, &tp));
+  }
+  {
+    // Test with femtosecond resolution.
+    using D = chrono::duration<std::int64_t, std::femto>;
+    time_point<D> tp;
+
+    // Max time_point<D> is 1970-01-01T02:33:43.372036854775807+00:00.
+    EXPECT_TRUE(parse(RFC3339_full,
+                      "1970-01-01T02:33:43.3720368547758079+00:00", utc, &tp));
+    EXPECT_EQ(tp, time_point<D>::max());
+    EXPECT_EQ("1970-01-01T02:33:43.372036854775807+00:00",
+              cctz::format(RFC3339_full, tp, utc));
+    // 1 femtosecond beyond max should fail.
+    EXPECT_FALSE(parse(RFC3339_full,
+                       "1970-01-01T02:33:43.3720368547758080+00:00", utc, &tp));
+
+    // Min time_point<D> is 1969-12-31T21:26:16.627963145224192+00:00.
+    EXPECT_TRUE(parse(RFC3339_full,
+                      "1969-12-31T21:26:16.6279631452241920+00:00", utc, &tp));
+    EXPECT_EQ(tp, time_point<D>::min());
+    EXPECT_EQ("1969-12-31T21:26:16.627963145224192+00:00",
+              cctz::format(RFC3339_full, tp, utc));
+    // 1 femtosecond below min should fail.
+    EXPECT_FALSE(parse(RFC3339_full,
+                       "1969-12-31T21:26:16.6279631452241919+00:00", utc, &tp));
+  }
+  {
+    // Test with attosecond resolution.
+    using D = chrono::duration<std::int64_t, std::atto>;
+    time_point<D> tp;
+
+    // Max time_point<D> is 1970-01-01T00:00:09.223372036854775807+00:00,
+    // but cctz::parse() truncates (towards zero) to a femtosecond boundary,
+    // so the last three decimal places are lost.
+    EXPECT_TRUE(parse(RFC3339_full,
+                      "1970-01-01T00:00:09.223372036854775807+00:00", utc,
+                      &tp));
+    EXPECT_EQ(tp.time_since_epoch(), D{9223372036854775000LL});
+    EXPECT_EQ("1970-01-01T00:00:09.223372036854775+00:00",
+              cctz::format(RFC3339_full, tp, utc));
+    // Moving into the next femtosecond should fail.
+    EXPECT_FALSE(parse(RFC3339_full,
+                       "1970-01-01T00:00:09.223372036854776000+00:00", utc,
+                       &tp));
+
+    // Min time_point<D> is 1969-12-31T23:59:50.776627963145224192+00:00,
+    // but cctz::parse() truncates (towards zero) to a femtosecond boundary,
+    // so we must round up.
+    EXPECT_TRUE(parse(RFC3339_full,
+                      "1969-12-31T23:59:50.776627963145225000+00:00", utc,
+                      &tp));
+    EXPECT_EQ(tp.time_since_epoch(), D{-9223372036854775000LL});
+    EXPECT_EQ("1969-12-31T23:59:50.776627963145225+00:00",
+              cctz::format(RFC3339_full, tp, utc));
+    // 1 attosecond below min should fail.
+    EXPECT_FALSE(parse(RFC3339_full,
+                       "1969-12-31T23:59:50.776627963145224999+00:00", utc,
+                       &tp));
+  }
+  {
+    // Test with 1-second resolution using int8_t ([-128, 127] seconds).
+    using D = chrono::duration<std::int8_t>;
+    time_point<D> tp;
+
+    // Max time_point<D> is 1970-01-01T00:02:07+00:00.
+    EXPECT_TRUE(parse(RFC3339_full, "1970-01-01T00:02:07.9+00:00", utc, &tp));
+    EXPECT_EQ(tp, time_point<D>::max());
+    EXPECT_EQ("1970-01-01T00:02:07+00:00", cctz::format(RFC3339_full, tp, utc));
+    // 1 second beyond max should fail.
+    EXPECT_FALSE(parse(RFC3339_full, "1970-01-01T00:02:08+00:00", utc, &tp));
+
+    // Min time_point<D> is 1969-12-31T23:57:52+00:00.
+    EXPECT_TRUE(parse(RFC3339_full, "1969-12-31T23:57:52+00:00", utc, &tp));
+    EXPECT_EQ(tp, time_point<D>::min());
+    EXPECT_EQ("1969-12-31T23:57:52+00:00", cctz::format(RFC3339_full, tp, utc));
+    // 1 second below min should fail.
+    EXPECT_FALSE(parse(RFC3339_full, "1969-12-31T23:57:51+00:00", utc, &tp));
+  }
+  {
+    // Test with 1-minute resolution using int8_t ([-128, 127] minutes).
+    using D = chrono::duration<std::int8_t, std::ratio<60>>;
+    time_point<D> tp;
+
+    // Max time_point<D> is 1970-01-01T02:07:00+00:00.
+    EXPECT_TRUE(parse(RFC3339_full, "1970-01-01T02:07:00+00:00", utc, &tp));
+    EXPECT_EQ(tp, time_point<D>::max());
+    EXPECT_EQ("1970-01-01T02:07:00+00:00", cctz::format(RFC3339_full, tp, utc));
+    // 1 minute beyond max should fail.
+    EXPECT_FALSE(parse(RFC3339_full, "1970-01-01T02:08:00+00:00", utc, &tp));
+
+    // Min time_point<D> is 1969-12-31T21:52:00+00:00.
+    EXPECT_TRUE(parse(RFC3339_full, "1969-12-31T21:52:00+00:00", utc, &tp));
+    EXPECT_EQ(tp, time_point<D>::min());
+    EXPECT_EQ("1969-12-31T21:52:00+00:00", cctz::format(RFC3339_full, tp, utc));
+    // 1 minute below min should fail.
+    EXPECT_FALSE(parse(RFC3339_full, "1969-12-31T21:51:00+00:00", utc, &tp));
+  }
+  {
+    // Test with millisecond resolution using int8_t ([-128, 127] milliseconds).
+    // This tests the case where Denom (1000) is larger than Rep max/min.
+    using D = chrono::duration<std::int8_t, std::milli>;
+    time_point<D> tp;
+
+    // Max time_point<D> is 1970-01-01T00:00:00.127+00:00.
+    EXPECT_TRUE(parse(RFC3339_full, "1970-01-01T00:00:00.127+00:00", utc, &tp));
+    EXPECT_EQ(tp, time_point<D>::max());
+    // 1 millisecond beyond max should fail (tests sub > max check).
+    EXPECT_FALSE(
+        parse(RFC3339_full, "1970-01-01T00:00:00.128+00:00", utc, &tp));
+
+    // Min time_point<D> is 1969-12-31T23:59:59.872+00:00.
+    EXPECT_TRUE(parse(RFC3339_full, "1969-12-31T23:59:59.872+00:00", utc, &tp));
+    EXPECT_EQ(tp, time_point<D>::min());
+    // 1 millisecond below min should fail (tests min with Denom > -min).
+    EXPECT_FALSE(
+        parse(RFC3339_full, "1969-12-31T23:59:59.871+00:00", utc, &tp));
+  }
+}
+
+TEST(Parse, TimePointFloatingPoint) {
+  const time_zone utc = utc_time_zone();
+  {
+    using D = chrono::duration<double>;
+    time_point<D> tp;
+
+    EXPECT_TRUE(parse(RFC3339_full, "1970-01-01T00:00:59.25+00:00", utc, &tp));
+    EXPECT_EQ(tp.time_since_epoch(), D{59.25});
+    EXPECT_TRUE(parse(RFC3339_full, "1969-12-31T23:59:00.75+00:00", utc, &tp));
+    EXPECT_EQ(tp.time_since_epoch(), D{-59.25});
+  }
+  {
+    using D = chrono::duration<double, std::milli>;
+    time_point<D> tp;
+
+    EXPECT_TRUE(
+        parse(RFC3339_full, "1970-01-01T00:00:00.015625+00:00", utc, &tp));
+    EXPECT_EQ(tp.time_since_epoch(), D{15.625});
+    EXPECT_TRUE(
+        parse(RFC3339_full, "1969-12-31T23:59:59.984375+00:00", utc, &tp));
+    EXPECT_EQ(tp.time_since_epoch(), D{-15.625});
+  }
+  {
+    using D = chrono::duration<double, std::ratio<60>>;
+    time_point<D> tp;
+
+    EXPECT_TRUE(parse(RFC3339_full, "1970-01-01T00:01:15+00:00", utc, &tp));
+    EXPECT_EQ(tp.time_since_epoch(), D{1.25});
+    EXPECT_TRUE(parse(RFC3339_full, "1969-12-31T23:58:45+00:00", utc, &tp));
+    EXPECT_EQ(tp.time_since_epoch(), D{-1.25});
+  }
+}
+
+TEST(Parse, RatioNonLowestTerms) {
+  const time_zone utc = utc_time_zone();
+  using D = chrono::duration<std::int64_t, std::ratio<2, 2>>;
   time_point<D> tp;
 
-  // Max representable time_point<D> is 2262-04-11T23:47:16.854775807 UTC.
-  EXPECT_TRUE(
-      parse(RFC3339_full, "2262-04-11T23:47:16.8547758079+00:00", utc, &tp));
-  EXPECT_EQ(tp, time_point<D>::max());
-  EXPECT_EQ("2262-04-11T23:47:16.854775807+00:00",
-            cctz::format(RFC3339_full, tp, utc));
-
-  // 1 nanosecond beyond max should fail.
-  EXPECT_FALSE(
-      parse(RFC3339_full, "2262-04-11T23:47:16.8547758080+00:00", utc, &tp));
-
-  // Min representable time_point<D> is 1677-09-21T00:12:43.145224192 UTC.
-  EXPECT_TRUE(
-      parse(RFC3339_full, "1677-09-21T00:12:43.1452241920+00:00", utc, &tp));
-  EXPECT_EQ(tp, time_point<D>::min());
-  EXPECT_EQ("1677-09-21T00:12:43.145224192+00:00",
-            cctz::format(RFC3339_full, tp, utc));
-
-  // 1 nanosecond below min should fail.
-  EXPECT_FALSE(
-      parse(RFC3339_full, "1677-09-21T00:12:43.1452241919+00:00", utc, &tp));
-
-  // Test with femtosecond resolution.
-  using DF = chrono::duration<std::int64_t, std::femto>;
-  time_point<DF> ftp;
-
-  // Max representable time_point<DF> is 1970-01-01T02:33:43.372036854775807
-  // UTC.
-  EXPECT_TRUE(parse(RFC3339_full, "1970-01-01T02:33:43.3720368547758079+00:00",
-                    utc, &ftp));
-  EXPECT_EQ(ftp, time_point<DF>::max());
-  EXPECT_EQ("1970-01-01T02:33:43.372036854775807+00:00",
-            cctz::format(RFC3339_full, ftp, utc));
-  // 1 femtosecond beyond max should fail.
-  EXPECT_FALSE(parse(RFC3339_full, "1970-01-01T02:33:43.3720368547758080+00:00",
-                     utc, &ftp));
-
-  // Min representable time_point<DF> is 1969-12-31T21:26:16.627963145224192
-  // UTC.
-  EXPECT_TRUE(parse(RFC3339_full, "1969-12-31T21:26:16.6279631452241920+00:00",
-                    utc, &ftp));
-  EXPECT_EQ(ftp, time_point<DF>::min());
-  EXPECT_EQ("1969-12-31T21:26:16.627963145224192+00:00",
-            cctz::format(RFC3339_full, ftp, utc));
-  // 1 femtosecond below min should fail.
-  EXPECT_FALSE(parse(RFC3339_full, "1969-12-31T21:26:16.6279631452241919+00:00",
-                     utc, &ftp));
-
-  // Test with attosecond resolution.
-  using DA = chrono::duration<std::int64_t, std::atto>;
-  time_point<DA> atp;
-
-  // 9 seconds fits in 64-bit attoseconds.
-  EXPECT_TRUE(parse(RFC3339_full, "1970-01-01T00:00:09.223372036854775+00:00",
-                    utc, &atp));
-  EXPECT_EQ(atp.time_since_epoch().count(), 9223372036854775000LL);
-  // 10 seconds exceeds 64-bit attoseconds limit.
-  EXPECT_FALSE(parse(RFC3339_full, "1970-01-01T00:00:10+00:00", utc, &atp));
-
-  // -9 seconds fits in 64-bit attoseconds.
-  EXPECT_TRUE(parse(RFC3339_full, "1969-12-31T23:59:51+00:00", utc, &atp));
-  EXPECT_EQ(atp.time_since_epoch().count(), -9000000000000000000LL);
-  // -10 seconds underflows 64-bit attoseconds limit.
-  EXPECT_FALSE(parse(RFC3339_full, "1969-12-31T23:59:50+00:00", utc, &atp));
-
-  // Test with 1-second resolution using int8_t (very narrow range: [-128, 127] seconds).
-  using DS = chrono::duration<std::int8_t, chrono::seconds::period>;
-  time_point<DS> stp;
-
-  // Max: 127 seconds.
-  EXPECT_TRUE(parse(RFC3339_full, "1970-01-01T00:02:07.9+00:00", utc, &stp));
-  EXPECT_EQ(stp, time_point<DS>::max());
-  EXPECT_EQ("1970-01-01T00:02:07+00:00", cctz::format(RFC3339_full, stp, utc));
-  // 128 seconds should fail.
-  EXPECT_FALSE(parse(RFC3339_full, "1970-01-01T00:02:08+00:00", utc, &stp));
-
-  // Min: -128 seconds.
-  EXPECT_TRUE(parse(RFC3339_full, "1969-12-31T23:57:52+00:00", utc, &stp));
-  EXPECT_EQ(stp, time_point<DS>::min());
-  EXPECT_EQ("1969-12-31T23:57:52+00:00", cctz::format(RFC3339_full, stp, utc));
-  // -129 seconds should fail.
-  EXPECT_FALSE(parse(RFC3339_full, "1969-12-31T23:57:51.9+00:00", utc, &stp));
-
-  // Test with 1-minute resolution using int8_t (range: [-128, 127] minutes).
-  using DM = chrono::duration<std::int8_t, chrono::minutes::period>;
-  time_point<DM> mtp;
-
-  // Max: 127 minutes (02:07).
-  EXPECT_TRUE(parse(RFC3339_full, "1970-01-01T02:07:59+00:00", utc, &mtp));
-  EXPECT_EQ(mtp, time_point<DM>::max());
-  EXPECT_EQ("1970-01-01T02:07:00+00:00", cctz::format(RFC3339_full, mtp, utc));
-  // 128 minutes (02:08) should fail.
-  EXPECT_FALSE(parse(RFC3339_full, "1970-01-01T02:08:00+00:00", utc, &mtp));
-
-  // Min: -128 minutes (21:52).
-  EXPECT_TRUE(parse(RFC3339_full, "1969-12-31T21:52:00+00:00", utc, &mtp));
-  EXPECT_EQ(mtp, time_point<DM>::min());
-  EXPECT_EQ("1969-12-31T21:52:00+00:00", cctz::format(RFC3339_full, mtp, utc));
-  // -129 minutes (21:51:59) should fail.
-  EXPECT_FALSE(parse(RFC3339_full, "1969-12-31T21:51:59+00:00", utc, &mtp));
-
-  // Test with millisecond resolution using int8_t (range: [-128, 127] milliseconds).
-  // This tests the case where Denom (1000) is larger than Rep max/min (127/-128).
-  using D_milli_int8 = chrono::duration<std::int8_t, std::milli>;
-  time_point<D_milli_int8> milli_stp;
-
-  // Max: 127 milliseconds.
-  EXPECT_TRUE(parse(RFC3339_full, "1970-01-01T00:00:00.127+00:00", utc, &milli_stp));
-  EXPECT_EQ(milli_stp.time_since_epoch().count(), 127);
-  // 128 milliseconds should fail (tests sub > max check).
-  EXPECT_FALSE(parse(RFC3339_full, "1970-01-01T00:00:00.128+00:00", utc, &milli_stp));
-
-  // Min: -128 milliseconds (1969-12-31T23:59:59.872 is -128ms).
-  EXPECT_TRUE(parse(RFC3339_full, "1969-12-31T23:59:59.872+00:00", utc, &milli_stp));
-  EXPECT_EQ(milli_stp.time_since_epoch().count(), -128);
-  // -129 milliseconds should fail (tests min boundary with Denom > -min).
-  EXPECT_FALSE(parse(RFC3339_full, "1969-12-31T23:59:59.871+00:00", utc, &milli_stp));
-
-  // Test with floating-point representation.
-  using DD = chrono::duration<double>;
-  time_point<DD> dtp;
-
-  EXPECT_TRUE(parse(RFC3339_full, "1970-01-01T00:00:01+00:00", utc, &dtp));
-  EXPECT_EQ(dtp.time_since_epoch().count(), 1.0);
-  EXPECT_TRUE(parse(RFC3339_full, "1969-12-31T23:59:59+00:00", utc, &dtp));
-  EXPECT_EQ(dtp.time_since_epoch().count(), -1.0);
-
-  using DD_milli = chrono::duration<double, std::milli>;
-  time_point<DD_milli> mdtp;
-
-  EXPECT_TRUE(parse(RFC3339_full, "1970-01-01T00:00:00.5+00:00", utc, &mdtp));
-  EXPECT_EQ(mdtp.time_since_epoch().count(), 500.0);
-  EXPECT_TRUE(parse(RFC3339_full, "1969-12-31T23:59:59.5+00:00", utc, &mdtp));
-  EXPECT_EQ(mdtp.time_since_epoch().count(), -500.0);
+  EXPECT_TRUE(parse(RFC3339_full, "2026-08-17T11:42:16-04:00", utc, &tp));
+  ExpectTime(tp, utc, 2026, 8, 17, 15, 42, 16, 0, false, "UTC");
 }
 
 TEST(Parse, TimePointOverflowFloor) {


### PR DESCRIPTION
Improve the precision of overflow and underflow checks in the `join_seconds` template function:
  - Use `std::intmax_t` for intermediate subsecond calculations to prevent premature overflow when the target representation type is small.
  - Refine the underflow check to correctly handle boundary cases near the minimum limit, avoiding unsafe subtraction.
  - Handle cases where the duration denominator is larger than the maximum limit of the representation type.
  - Support floating-point duration representations.
  - Reduce duration periods to lowest terms via `typename Period::type` in `cctz::parse()` to support non-reduced ratios.
  - Align `detail::split_seconds()` with floor semantics for pre-epoch times.

Fixes #199