### PR TITLE
reject unsafe paths in FuchsiaZoneInfoSource::Open

### DIFF
--- a/src/time_zone_info.cc
+++ b/src/time_zone_info.cc
@@ -572,6 +572,11 @@ std::unique_ptr<ZoneInfoSource> FuchsiaZoneInfoSource::Open(
   // Use of the "file:" prefix is intended for testing purposes only.
   const std::size_t pos = (name.compare(0, 5, "file:") == 0) ? 5 : 0;
 
+  // Reject unsafe paths (e.g., "../../etc/passwd").
+  if (UnsafePath(name, pos)) {
+    return nullptr;
+  }
+
   // Prefixes where a Fuchsia component might find zoneinfo files,
   // in descending order of preference.
   const auto kTzdataPrefixes = {


### PR DESCRIPTION
FuchsiaZoneInfoSource::Open() appends the zone name to one of the fixed tzdata prefixes and hands the result to FOpen(), but it never runs the UnsafePath() check that FileZoneInfoSource::Open() got in #353. Since FileZoneInfoSource::Open() now returns null for a traversing name, the lookup chain in TimeZoneInfo::Load() falls through to this source, which happily opens it: load_time_zone("../../../secret") resolves to <prefix>/zoneinfo/tzif2/../../../secret and reads a file outside the tzdata root. AndroidZoneInfoSource::Open() only strcmp()s the name against index entries, so it is unaffected.

The check belongs here rather than in the caller because each source owns its own prefix and path assembly, so only the source knows what "inside the root" means. I confirmed it by building with the Fuchsia prefixes redirected at a scratch directory: the traversing names load a file one level above the root before the change and are rejected after it, while a normal America/Los_Angeles under <prefix>/zoneinfo/tzif2/ still loads. The existing traversal cases in TimeZone.Failures pass either way on non-Fuchsia hosts only because none of those prefixes exist there.