### PR TITLE
avoid signed overflow computing start offset in AndroidZoneInfoSource

### DIFF
--- a/src/time_zone_info.cc
+++ b/src/time_zone_info.cc
@@ -536,7 +536,8 @@ std::unique_ptr<ZoneInfoSource> AndroidZoneInfoSource::Open(
       const std::int_fast64_t start =
           static_cast<std::int_fast64_t>(data_offset) + Decode32(ebuf + 40);
       const std::int_fast32_t length = Decode32(ebuf + 44);
-      if (start < 0 || length < 0) break;
+      if (start < 0 || start > std::numeric_limits<long>::max() || length < 0)
+        break;  // fseek() takes a long
       ebuf[40] = '\0';  // ensure zone name is NUL terminated
       if (strcmp(name.c_str() + pos, ebuf) == 0) {
         if (fseek(fp.get(), static_cast<long>(start), SEEK_SET) != 0) break;

--- a/src/time_zone_info.cc
+++ b/src/time_zone_info.cc
@@ -47,6 +47,7 @@
 #include <cstring>
 #include <fstream>
 #include <functional>
+#include <limits>
 #include <memory>
 #include <sstream>
 #include <string>
@@ -534,10 +535,11 @@ std::unique_ptr<ZoneInfoSource> AndroidZoneInfoSource::Open(
     for (std::size_t i = 0; i != zonecnt; ++i) {
       if (fread(ebuf, 1, sizeof(ebuf), fp.get()) != sizeof(ebuf)) break;
       const std::int_fast64_t start =
-          static_cast<std::int_fast64_t>(data_offset) + Decode32(ebuf + 40);
+          std::int_fast64_t{data_offset} + Decode32(ebuf + 40);
       const std::int_fast32_t length = Decode32(ebuf + 44);
-      if (start < 0 || start > std::numeric_limits<long>::max() || length < 0)
-        break;  // fseek() takes a long
+      if (start < 0 || length < 0) break;
+      // fseek() takes a long
+      if (start > std::numeric_limits<long>::max()) break;
       ebuf[40] = '\0';  // ensure zone name is NUL terminated
       if (strcmp(name.c_str() + pos, ebuf) == 0) {
         if (fseek(fp.get(), static_cast<long>(start), SEEK_SET) != 0) break;

--- a/src/time_zone_info.cc
+++ b/src/time_zone_info.cc
@@ -533,7 +533,8 @@ std::unique_ptr<ZoneInfoSource> AndroidZoneInfoSource::Open(
     if (zonecnt * sizeof(ebuf) != index_size) continue;
     for (std::size_t i = 0; i != zonecnt; ++i) {
       if (fread(ebuf, 1, sizeof(ebuf), fp.get()) != sizeof(ebuf)) break;
-      const std::int_fast32_t start = data_offset + Decode32(ebuf + 40);
+      const std::int_fast64_t start =
+          static_cast<std::int_fast64_t>(data_offset) + Decode32(ebuf + 40);
       const std::int_fast32_t length = Decode32(ebuf + 44);
       if (start < 0 || length < 0) break;
       ebuf[40] = '\0';  // ensure zone name is NUL terminated


### PR DESCRIPTION
AndroidZoneInfoSource::Open decodes each index entry's absolute data offset as `data_offset + Decode32(ebuf + 40)`, where both operands come from a loaded, untrusted tzdata database. `std::int_fast32_t` is 32 bits on Bionic, macOS, and Windows, so a crafted index with `data_offset` and an entry offset near `INT32_MAX` overflows the addition before the `start < 0` guard ever runs (UBSan flags `2147483647 + 2147483646`).

Do the sum in `int_fast64_t` before the range check, the same way the TZif reader in `Load()` guards its decoded values. Real tzdata offsets stay well under `INT32_MAX`, so valid zones are unaffected; only the hostile case changes, and it now fails the bounds check cleanly instead of relying on undefined behavior.
