### PR TITLE
Reject extended zones whose transitions remain in negative unix time

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -115,7 +115,10 @@ cc_test(
 cc_test(
     name = "time_zone_lookup_test",
     size = "small",
-    srcs = ["src/time_zone_lookup_test.cc"],
+    srcs = [
+        "src/time_zone_lookup_test.cc",
+        "src/tzfile.h",
+    ],
     deps = [
         ":civil_time",
         ":test_time_zone_names",
@@ -163,8 +166,8 @@ cc_test(
     name = "time_zone_posix_test",
     size = "small",
     srcs = [
-      "src/time_zone_posix_test.cc",
-      "src/time_zone_posix.h",
+        "src/time_zone_posix.h",
+        "src/time_zone_posix_test.cc",
     ],
     deps = [
         ":civil_time",

--- a/src/time_zone_info.cc
+++ b/src/time_zone_info.cc
@@ -800,17 +800,13 @@ bool TimeZoneInfo::Load(ZoneInfoSource* zip) {
   // time line (the first half is handled above) so that the signed
   // difference between a civil_second and the civil_second of its
   // previous transition is always representable, without overflow.
-  // Note: For zones extended with a future POSIX spec (extended_ == true),
-  // future times are handled by 400-year cycle shifting. Appending a static
-  // transition would corrupt the extended transition table.
-  if (!extended_) {
-    const Transition& last(transitions_.back());
-    if (last.unix_time < 0) {
-      const std::uint_fast8_t type_index = last.type_index;
-      Transition& tr(*transitions_.emplace(transitions_.end()));
-      tr.unix_time = 2147483647;  // 2038-01-19T03:14:07+00:00
-      tr.type_index = type_index;
-    }
+  const Transition& last(transitions_.back());
+  if (last.unix_time < 0) {
+    if (extended_) return false;
+    const std::uint_fast8_t type_index = last.type_index;
+    Transition& tr(*transitions_.emplace(transitions_.end()));
+    tr.unix_time = 2147483647;  // 2038-01-19T03:14:07+00:00
+    tr.type_index = type_index;
   }
 
   // Compute the local civil time for each transition and the preceding
@@ -929,17 +925,9 @@ time_zone::absolute_lookup TimeZoneInfo::BreakTime(
     // future_spec_, shift back to a supported year using the 400-year
     // cycle of calendaric equivalence and then compensate accordingly.
     if (extended_) {
-      // Use unsigned 64-bit subtraction to avoid signed overflow when
-      // unix_time > 0 and the last transition's unix_time is negative.
-      const std::uint_fast64_t diff =
-          static_cast<std::uint_fast64_t>(unix_time) -
-          static_cast<std::uint_fast64_t>(transitions_[timecnt - 1].unix_time);
-      year_t shift = static_cast<year_t>(diff / kSecsPer400Years + 1);
-      // Clamp shift to prevent shift * kSecsPer400Years from overflowing
-      // seconds when querying far-future timestamps (e.g. seconds::max()).
-      if (shift > seconds::max().count() / kSecsPer400Years) {
-        shift = seconds::max().count() / kSecsPer400Years;
-      }
+      const std::int_fast64_t diff =
+          unix_time - transitions_[timecnt - 1].unix_time;
+      const year_t shift = diff / kSecsPer400Years + 1;
       const auto d = seconds(shift * kSecsPer400Years);
       time_zone::absolute_lookup al = BreakTime(tp - d);
       al.cs = YearShift(al.cs, shift * 400);
@@ -1012,19 +1000,8 @@ time_zone::civil_lookup TimeZoneInfo::MakeTime(const civil_second& cs) const {
       // future_spec_, shift back to a supported year using the 400-year
       // cycle of calendaric equivalence and then compensate accordingly.
       if (extended_ && cs.year() > last_year_) {
-        // Use unsigned 64-bit arithmetic to safely compute the year difference
-        // and avoid signed overflow when last_year_ is negative.
-        const std::uint_fast64_t diff =
-            static_cast<std::uint_fast64_t>(cs.year()) -
-            static_cast<std::uint_fast64_t>(last_year_ + 1);
-        const year_t shift = static_cast<year_t>(diff / 400 + 1);
-        // Map cs.year() to the 400-year cycle in (last_year_ - 400, last_year_]
-        // without intermediate multiplications that could overflow year_t.
-        const year_t shifted_year =
-            last_year_ - 399 + static_cast<year_t>(diff % 400);
-        const civil_second shifted_cs(shifted_year, cs.month(), cs.day(),
-                                      cs.hour(), cs.minute(), cs.second());
-        return TimeLocal(shifted_cs, shift);
+        const year_t shift = (cs.year() - last_year_ - 1) / 400 + 1;
+        return TimeLocal(YearShift(cs, shift * -400), shift);
       }
       const TransitionType& tt(transition_types_[tr->type_index]);
       if (cs > tt.civil_max) return MakeUnique(time_point<seconds>::max());

--- a/src/time_zone_info.cc
+++ b/src/time_zone_info.cc
@@ -800,12 +800,17 @@ bool TimeZoneInfo::Load(ZoneInfoSource* zip) {
   // time line (the first half is handled above) so that the signed
   // difference between a civil_second and the civil_second of its
   // previous transition is always representable, without overflow.
-  const Transition& last(transitions_.back());
-  if (last.unix_time < 0) {
-    const std::uint_fast8_t type_index = last.type_index;
-    Transition& tr(*transitions_.emplace(transitions_.end()));
-    tr.unix_time = 2147483647;  // 2038-01-19T03:14:07+00:00
-    tr.type_index = type_index;
+  // Note: For zones extended with a future POSIX spec (extended_ == true),
+  // future times are handled by 400-year cycle shifting. Appending a static
+  // transition would corrupt the extended transition table.
+  if (!extended_) {
+    const Transition& last(transitions_.back());
+    if (last.unix_time < 0) {
+      const std::uint_fast8_t type_index = last.type_index;
+      Transition& tr(*transitions_.emplace(transitions_.end()));
+      tr.unix_time = 2147483647;  // 2038-01-19T03:14:07+00:00
+      tr.type_index = type_index;
+    }
   }
 
   // Compute the local civil time for each transition and the preceding
@@ -924,9 +929,17 @@ time_zone::absolute_lookup TimeZoneInfo::BreakTime(
     // future_spec_, shift back to a supported year using the 400-year
     // cycle of calendaric equivalence and then compensate accordingly.
     if (extended_) {
-      const std::int_fast64_t diff =
-          unix_time - transitions_[timecnt - 1].unix_time;
-      const year_t shift = diff / kSecsPer400Years + 1;
+      // Use unsigned 64-bit subtraction to avoid signed overflow when
+      // unix_time > 0 and the last transition's unix_time is negative.
+      const std::uint_fast64_t diff =
+          static_cast<std::uint_fast64_t>(unix_time) -
+          static_cast<std::uint_fast64_t>(transitions_[timecnt - 1].unix_time);
+      year_t shift = static_cast<year_t>(diff / kSecsPer400Years + 1);
+      // Clamp shift to prevent shift * kSecsPer400Years from overflowing
+      // seconds when querying far-future timestamps (e.g. seconds::max()).
+      if (shift > seconds::max().count() / kSecsPer400Years) {
+        shift = seconds::max().count() / kSecsPer400Years;
+      }
       const auto d = seconds(shift * kSecsPer400Years);
       time_zone::absolute_lookup al = BreakTime(tp - d);
       al.cs = YearShift(al.cs, shift * 400);
@@ -999,8 +1012,19 @@ time_zone::civil_lookup TimeZoneInfo::MakeTime(const civil_second& cs) const {
       // future_spec_, shift back to a supported year using the 400-year
       // cycle of calendaric equivalence and then compensate accordingly.
       if (extended_ && cs.year() > last_year_) {
-        const year_t shift = (cs.year() - last_year_ - 1) / 400 + 1;
-        return TimeLocal(YearShift(cs, shift * -400), shift);
+        // Use unsigned 64-bit arithmetic to safely compute the year difference
+        // and avoid signed overflow when last_year_ is negative.
+        const std::uint_fast64_t diff =
+            static_cast<std::uint_fast64_t>(cs.year()) -
+            static_cast<std::uint_fast64_t>(last_year_ + 1);
+        const year_t shift = static_cast<year_t>(diff / 400 + 1);
+        // Map cs.year() to the 400-year cycle in (last_year_ - 400, last_year_]
+        // without intermediate multiplications that could overflow year_t.
+        const year_t shifted_year =
+            last_year_ - 399 + static_cast<year_t>(diff % 400);
+        const civil_second shifted_cs(shifted_year, cs.month(), cs.day(),
+                                      cs.hour(), cs.minute(), cs.second());
+        return TimeLocal(shifted_cs, shift);
       }
       const TransitionType& tt(transition_types_[tr->type_index]);
       if (cs > tt.civil_max) return MakeUnique(time_point<seconds>::max());

--- a/src/time_zone_lookup_test.cc
+++ b/src/time_zone_lookup_test.cc
@@ -950,8 +950,11 @@ class StringZoneInfoSource : public ZoneInfoSource {
 };
 
 // Constructs a minimal valid TZif2 string with a single 64-bit transition
-// at the given unix_time and a future POSIX DST footer ("EST5EDT,M3.2.0,M11.1.0").
-std::string MakeNegativeEpochTzif(std::int_fast64_t unix_time) {
+// at the given transition time and a future POSIX rule.
+std::string MakeExtendedTzif(std::int_fast64_t unix_time,
+                             std::int_fast32_t utc_offset,
+                             const std::string& abbr,
+                             const std::string& future_spec) {
   std::string s;
   auto append32 = [&s](std::int_fast32_t v) {
     const std::int_fast32_t s32max = 0x7fffffff;
@@ -980,86 +983,94 @@ std::string MakeNegativeEpochTzif(std::int_fast64_t unix_time) {
     }
   };
 
+  const std::size_t charcnt = abbr.size() + 1;
+
   // 32-bit header
   s.append(TZ_MAGIC, 4);
-  s.push_back('2');
+  s.push_back('2');    // tzh_version
   s.append(15, '\0');  // tzh_reserved
   append32(0);         // tzh_ttisutcnt
   append32(0);         // tzh_ttisstdcnt
   append32(0);         // tzh_leapcnt
   append32(0);         // tzh_timecnt (0 32-bit transitions)
   append32(1);         // tzh_typecnt (1 ttinfo record)
-  append32(4);         // tzh_charcnt (4 bytes for "EST\0")
+  append32(static_cast<std::int_fast32_t>(charcnt));  // tzh_charcnt
 
   // 32-bit data block
-  append32(-18000);      // tt_utoff (-5 hours)
-  s.push_back(0);        // tt_isdst (standard time)
-  s.push_back(0);        // tt_desigidx ("EST\0")
-  s.append("EST\0", 4);  // string table
+  append32(utc_offset);               // tt_utoff
+  s.push_back(0);                     // tt_isdst (standard time)
+  s.push_back(0);                     // tt_desigidx
+  s.append(abbr.data(), charcnt);     // abbreviation table
 
   // 64-bit header
   s.append(TZ_MAGIC, 4);
-  s.push_back('2');
+  s.push_back('2');    // tzh_version
   s.append(15, '\0');  // tzh_reserved
   append32(0);         // tzh_ttisutcnt
   append32(0);         // tzh_ttisstdcnt
   append32(0);         // tzh_leapcnt
   append32(1);         // tzh_timecnt (1 64-bit transition)
   append32(1);         // tzh_typecnt (1 ttinfo record)
-  append32(4);         // tzh_charcnt (4 bytes for "EST\0")
+  append32(static_cast<std::int_fast32_t>(charcnt));  // tzh_charcnt
 
   // 64-bit data block
-  append64(unix_time);   // unix_time
-  s.push_back(0);        // type index for transition
-  append32(-18000);      // tt_utoff (-5 hours)
-  s.push_back(0);        // tt_isdst (standard time)
-  s.push_back(0);        // tt_desigidx ("EST\0")
-  s.append("EST\0", 4);  // string table
+  append64(unix_time);                // transition time
+  s.push_back(0);                     // type index for transition
+  append32(utc_offset);               // tt_utoff
+  s.push_back(0);                     // tt_isdst (standard time)
+  s.push_back(0);                     // tt_desigidx
+  s.append(abbr.data(), charcnt);     // abbreviation table
 
   // POSIX footer
-  s.append("\nEST5EDT,M3.2.0,M11.1.0\n");
+  s.push_back('\n');
+  s.append(future_spec);
+  s.push_back('\n');
   return s;
 }
 
-std::unique_ptr<ZoneInfoSource> NegativeEpochTestFactory(
+std::unique_ptr<ZoneInfoSource> ExtendedTestFactory(
     const std::string& name,
     const std::function<std::unique_ptr<ZoneInfoSource>(const std::string&)>&
         fallback) {
-  if (name == "test:negative_epoch_dst") {
-    // 1900-01-01T00:00:00Z (-2208988800) is in negative epoch, but extending
-    // 401 years reaches 2301 AD in the positive unix_time space.
-    return std::unique_ptr<ZoneInfoSource>(
-        new StringZoneInfoSource(MakeNegativeEpochTzif(-2208988800LL)));
+  if (name == "test:extended_dst") {
+    // 1900-01-01T00:00:00Z (-2208988800) is before epoch, but extending
+    // 401 years reaches 2301 AD in the positive unix time space.
+    return std::unique_ptr<ZoneInfoSource>(new StringZoneInfoSource(
+        MakeExtendedTzif(-2208988800LL, -5 * 3600, "EST",
+                         "EST5EDT,M3.2.0,M11.1.0")));
   }
-  if (name == "test:negative_epoch_dst_too_far") {
-    // Year -1201 (-100000000000) is so far in the negative epoch that extending
-    // 401 years still leaves the last transition before 1970 (<0).
-    return std::unique_ptr<ZoneInfoSource>(
-        new StringZoneInfoSource(MakeNegativeEpochTzif(-100000000000LL)));
+  if (name == "test:extended_dst_too_far") {
+    // Year -1201 (-100000000000) is so far before epoch that extending
+    // 401 years still leaves the last transition in the negative unix time space.
+    return std::unique_ptr<ZoneInfoSource>(new StringZoneInfoSource(
+        MakeExtendedTzif(-100000000000LL, -5 * 3600, "EST",
+                         "EST5EDT,M3.2.0,M11.1.0")));
   }
   return fallback(name);
 }
 
-// Tests loading a TZif file whose explicit transitions end in negative epoch
+// Tests loading a TZif file whose explicit transitions end before epoch
 // with a POSIX DST footer string.
-TEST(TimeZoneEdgeCase, NegativeEpochExtended) {
+TEST(TimeZoneEdgeCase, ExtendedBeforeEpoch) {
   auto prev_factory = cctz_extension::zone_info_source_factory;
-  cctz_extension::zone_info_source_factory = NegativeEpochTestFactory;
-  time_zone tz;
-  ASSERT_TRUE(load_time_zone("test:negative_epoch_dst", &tz));
+  cctz_extension::zone_info_source_factory = ExtendedTestFactory;
 
-  // Summer (July) must use the POSIX DST rule (EDT, UTC-4).
+  time_zone tz;
+  ASSERT_TRUE(load_time_zone("test:extended_dst", &tz));
+
+  // July matches the future rule for EDT (UTC-4).
   auto tp_july = convert(civil_second(2026, 7, 20, 12, 0, 0), tz);
   ExpectTime(tp_july, tz, 2026, 7, 20, 12, 0, 0, -4 * 3600, true, "EDT");
   EXPECT_STREQ("EDT", tz.lookup(tp_july).abbr);
 
-  // Winter (January) must use EST (UTC-5).
+  // January matches the future rule for EST (UTC-5).
   auto tp_jan = convert(civil_second(2026, 1, 20, 12, 0, 0), tz);
   ExpectTime(tp_jan, tz, 2026, 1, 20, 12, 0, 0, -5 * 3600, false, "EST");
   EXPECT_STREQ("EST", tz.lookup(tp_jan).abbr);
 
-  // Extended zones that do not reach non-negative unix_time are rejected.
-  EXPECT_FALSE(load_time_zone("test:negative_epoch_dst_too_far", &tz));
+  // Extended zones that do not reach non-negative unix time are rejected.
+  EXPECT_FALSE(load_time_zone("test:extended_dst_too_far", &tz));
+
   cctz_extension::zone_info_source_factory = prev_factory;
 }
 

--- a/src/time_zone_lookup_test.cc
+++ b/src/time_zone_lookup_test.cc
@@ -983,7 +983,7 @@ std::string MakeExtendedTzif(std::int_fast64_t unix_time,
     }
   };
 
-  const std::size_t charcnt = abbr.size() + 1;
+  const std::size_t charcnt = abbr.size() + 1;  // includes the trailing '\0'
 
   // 32-bit header
   s.append(TZ_MAGIC, 4);

--- a/src/time_zone_lookup_test.cc
+++ b/src/time_zone_lookup_test.cc
@@ -929,8 +929,6 @@ class StringZoneInfoSource : public ZoneInfoSource {
       : data_(std::move(data)), offset_(0) {}
 
   std::size_t Read(void* ptr, std::size_t size) override {
-    if (offset_ >= data_.size())
-      return 0;
     std::size_t n = (std::min)(size, data_.size() - offset_);
     std::memcpy(ptr, data_.data() + offset_, n);
     offset_ += n;
@@ -1000,7 +998,7 @@ std::string MakeExtendedTzif(std::int_fast64_t unix_time,
   append32(utc_offset);               // tt_utoff
   s.push_back(0);                     // tt_isdst (standard time)
   s.push_back(0);                     // tt_desigidx
-  s.append(abbr.data(), charcnt);     // abbreviation table
+  s.append(abbr.c_str(), charcnt);    // abbreviation table
 
   // 64-bit header
   s.append(TZ_MAGIC, 4);
@@ -1019,7 +1017,7 @@ std::string MakeExtendedTzif(std::int_fast64_t unix_time,
   append32(utc_offset);               // tt_utoff
   s.push_back(0);                     // tt_isdst (standard time)
   s.push_back(0);                     // tt_desigidx
-  s.append(abbr.data(), charcnt);     // abbreviation table
+  s.append(abbr.c_str(), charcnt);  // abbreviation table
 
   // POSIX footer
   s.push_back('\n');

--- a/src/time_zone_lookup_test.cc
+++ b/src/time_zone_lookup_test.cc
@@ -17,16 +17,21 @@
 #include <chrono>
 #include <cstddef>
 #include <cstdlib>
+#include <cstring>
 #include <future>
 #include <limits>
+#include <memory>
 #include <string>
 #include <thread>
+#include <utility>
 #include <vector>
+
 #if defined(__linux__)
 #include <features.h>
 #endif
 
 #include "cctz/civil_time.h"
+#include "cctz/zone_info_source.h"
 #include "gtest/gtest.h"
 #include "test_time_zone_names.h"
 
@@ -903,6 +908,125 @@ TEST(TimeZoneEdgeCase, UTC5DigitYear) {
   ExpectTime(tp, tz, 9999, 12, 31, 23, 59, 59, 0 * 3600, false, "UTC");
   tp += cctz::seconds(1);
   ExpectTime(tp, tz, 10000, 1, 1, 0, 0, 0, 0 * 3600, false, "UTC");
+}
+
+// A ZoneInfoSource implementation backed by an in-memory string buffer.
+class StringZoneInfoSource : public ZoneInfoSource {
+ public:
+  explicit StringZoneInfoSource(std::string data)
+      : data_(std::move(data)), offset_(0) {}
+
+  std::size_t Read(void* ptr, std::size_t size) override {
+    if (offset_ >= data_.size())
+      return 0;
+    std::size_t n = (std::min)(size, data_.size() - offset_);
+    std::memcpy(ptr, data_.data() + offset_, n);
+    offset_ += n;
+    return n;
+  }
+
+  int Skip(std::size_t offset) override {
+    if (offset > data_.size() - offset_)
+      return -1;
+    offset_ += offset;
+    return 0;
+  }
+
+ private:
+  std::string data_;
+  std::size_t offset_;
+};
+
+// Constructs a minimal valid TZif2 string with a single negative-epoch 64-bit
+// transition and a future POSIX DST footer ("EST5EDT,M3.2.0,M11.1.0").
+std::string MakeNegativeEpochTzif() {
+  std::string s;
+  auto append32 = [&s](std::uint32_t v) {
+    for (int i = 3; i >= 0; --i) {
+      s.push_back(static_cast<char>((v >> (i * 8)) & 0xff));
+    }
+  };
+  auto append64 = [&s](std::uint64_t v) {
+    for (int i = 7; i >= 0; --i) {
+      s.push_back(static_cast<char>((v >> (i * 8)) & 0xff));
+    }
+  };
+
+  // 32-bit header
+  s.append("TZif2", 5);
+  s.append(15, '\0');  // tzh_reserved
+  append32(0);         // tzh_ttisutcnt
+  append32(0);         // tzh_ttisstdcnt
+  append32(0);         // tzh_leapcnt
+  append32(0);         // tzh_timecnt (0 32-bit transitions)
+  append32(1);         // tzh_typecnt (1 ttinfo record)
+  append32(4);         // tzh_charcnt (4 bytes for "EST\0")
+
+  // 32-bit data block
+  append32(static_cast<std::uint32_t>(-18000));  // tt_utoff (-5 hours)
+  s.push_back(0);                                // tt_isdst (standard time)
+  s.push_back(0);                                // tt_desigidx ("EST\0")
+  s.append("EST\0", 4);                          // string table
+
+  // 64-bit header
+  s.append("TZif2", 5);
+  s.append(15, '\0');  // tzh_reserved
+  append32(0);         // tzh_ttisutcnt
+  append32(0);         // tzh_ttisstdcnt
+  append32(0);         // tzh_leapcnt
+  append32(1);         // tzh_timecnt (1 64-bit transition)
+  append32(1);         // tzh_typecnt (1 ttinfo record)
+  append32(4);         // tzh_charcnt (4 bytes for "EST\0")
+
+  // 64-bit data block
+  append64(static_cast<std::uint64_t>(
+      std::int64_t{-100000000000}));             // unix_time (year -1201)
+  s.push_back(0);                                // type index for transition
+  append32(static_cast<std::uint32_t>(-18000));  // tt_utoff (-5 hours)
+  s.push_back(0);                                // tt_isdst (standard time)
+  s.push_back(0);                                // tt_desigidx ("EST\0")
+  s.append("EST\0", 4);                          // string table
+
+  // POSIX footer
+  s.append("\nEST5EDT,M3.2.0,M11.1.0\n");
+  return s;
+}
+
+std::unique_ptr<ZoneInfoSource> NegativeEpochTestFactory(
+    const std::string& name,
+    const std::function<std::unique_ptr<ZoneInfoSource>(const std::string&)>&
+        fallback) {
+  if (name == "test:negative_epoch_dst") {
+    return std::unique_ptr<ZoneInfoSource>(
+        new StringZoneInfoSource(MakeNegativeEpochTzif()));
+  }
+  return fallback(name);
+}
+
+// Tests loading a TZif file whose explicit transitions end in negative epoch
+// with a POSIX DST footer string. Verifies that querying far-future time_points
+// does not cause signed integer overflow, and that lookups for modern dates use
+// the correct POSIX DST transition rules.
+TEST(TimeZoneEdgeCase, NegativeEpochExtended) {
+  auto prev_factory = cctz_extension::zone_info_source_factory;
+  cctz_extension::zone_info_source_factory = NegativeEpochTestFactory;
+  time_zone tz;
+  ASSERT_TRUE(load_time_zone("test:negative_epoch_dst", &tz));
+  cctz_extension::zone_info_source_factory = prev_factory;
+
+  // Far-future lookup must not trigger signed integer overflow.
+  // A sanitizer like UBSAN may flag the following line on overflow.
+  static_cast<void>(tz.lookup(time_point<seconds>::max()));
+
+  // Summer (July) must use the POSIX DST rule (EDT, UTC-4).
+  auto tp_july = convert(civil_second(2026, 7, 20, 12, 0, 0), tz);
+  ExpectTime(tp_july, tz, 2026, 7, 20, 12, 0, 0, -4 * 3600, true, "EDT");
+  EXPECT_EQ("EDT", std::string(tz.lookup(tp_july).abbr));
+
+  // Winter (January) must use EST (UTC-5).
+  auto tp_jan = convert(civil_second(2026, 1, 20, 12, 0, 0), tz);
+  ExpectTime(tp_jan, tz, 2026, 1, 20, 12, 0, 0, -5 * 3600, false, "EST");
+  EXPECT_EQ("EST", std::string(tz.lookup(tp_jan).abbr));
 }
 
 }  // namespace cctz

--- a/src/time_zone_lookup_test.cc
+++ b/src/time_zone_lookup_test.cc
@@ -34,6 +34,7 @@
 #include "cctz/zone_info_source.h"
 #include "gtest/gtest.h"
 #include "test_time_zone_names.h"
+#include "tzfile.h"
 
 namespace chrono = std::chrono;
 

--- a/src/time_zone_lookup_test.cc
+++ b/src/time_zone_lookup_test.cc
@@ -34,7 +34,6 @@
 #include "cctz/zone_info_source.h"
 #include "gtest/gtest.h"
 #include "test_time_zone_names.h"
-#include "tzfile.h"
 
 namespace chrono = std::chrono;
 

--- a/src/time_zone_lookup_test.cc
+++ b/src/time_zone_lookup_test.cc
@@ -34,6 +34,7 @@
 #include "cctz/zone_info_source.h"
 #include "gtest/gtest.h"
 #include "test_time_zone_names.h"
+#include "tzfile.h"
 
 namespace chrono = std::chrono;
 
@@ -937,23 +938,40 @@ class StringZoneInfoSource : public ZoneInfoSource {
   std::size_t offset_;
 };
 
-// Constructs a minimal valid TZif2 string with a single negative-epoch 64-bit
-// transition and a future POSIX DST footer ("EST5EDT,M3.2.0,M11.1.0").
-std::string MakeNegativeEpochTzif() {
+// Constructs a minimal valid TZif2 string with a single 64-bit transition
+// at the given unix_time and a future POSIX DST footer ("EST5EDT,M3.2.0,M11.1.0").
+std::string MakeNegativeEpochTzif(std::int_fast64_t unix_time) {
   std::string s;
-  auto append32 = [&s](std::uint32_t v) {
+  auto append32 = [&s](std::int_fast32_t v) {
+    const std::int_fast32_t s32max = 0x7fffffff;
+    const auto s32maxU = static_cast<std::uint_fast32_t>(s32max);
+    std::uint_fast32_t uv;
+    if (v >= 0) {
+      uv = static_cast<std::uint_fast32_t>(v);
+    } else {
+      uv = static_cast<std::uint_fast32_t>(v + s32max + 1) + s32maxU + 1;
+    }
     for (int i = 3; i >= 0; --i) {
-      s.push_back(static_cast<char>((v >> (i * 8)) & 0xff));
+      s.push_back(static_cast<char>((uv >> (i * 8)) & 0xff));
     }
   };
-  auto append64 = [&s](std::uint64_t v) {
+  auto append64 = [&s](std::int_fast64_t v) {
+    const std::int_fast64_t s64max = 0x7fffffffffffffff;
+    const auto s64maxU = static_cast<std::uint_fast64_t>(s64max);
+    std::uint_fast64_t uv;
+    if (v >= 0) {
+      uv = static_cast<std::uint_fast64_t>(v);
+    } else {
+      uv = static_cast<std::uint_fast64_t>(v + s64max + 1) + s64maxU + 1;
+    }
     for (int i = 7; i >= 0; --i) {
-      s.push_back(static_cast<char>((v >> (i * 8)) & 0xff));
+      s.push_back(static_cast<char>((uv >> (i * 8)) & 0xff));
     }
   };
 
   // 32-bit header
-  s.append("TZif2", 5);
+  s.append(TZ_MAGIC, 4);
+  s.push_back('2');
   s.append(15, '\0');  // tzh_reserved
   append32(0);         // tzh_ttisutcnt
   append32(0);         // tzh_ttisstdcnt
@@ -963,13 +981,14 @@ std::string MakeNegativeEpochTzif() {
   append32(4);         // tzh_charcnt (4 bytes for "EST\0")
 
   // 32-bit data block
-  append32(static_cast<std::uint32_t>(-18000));  // tt_utoff (-5 hours)
-  s.push_back(0);                                // tt_isdst (standard time)
-  s.push_back(0);                                // tt_desigidx ("EST\0")
-  s.append("EST\0", 4);                          // string table
+  append32(-18000);      // tt_utoff (-5 hours)
+  s.push_back(0);        // tt_isdst (standard time)
+  s.push_back(0);        // tt_desigidx ("EST\0")
+  s.append("EST\0", 4);  // string table
 
   // 64-bit header
-  s.append("TZif2", 5);
+  s.append(TZ_MAGIC, 4);
+  s.push_back('2');
   s.append(15, '\0');  // tzh_reserved
   append32(0);         // tzh_ttisutcnt
   append32(0);         // tzh_ttisstdcnt
@@ -979,13 +998,12 @@ std::string MakeNegativeEpochTzif() {
   append32(4);         // tzh_charcnt (4 bytes for "EST\0")
 
   // 64-bit data block
-  append64(static_cast<std::uint64_t>(
-      std::int64_t{-100000000000}));             // unix_time (year -1201)
-  s.push_back(0);                                // type index for transition
-  append32(static_cast<std::uint32_t>(-18000));  // tt_utoff (-5 hours)
-  s.push_back(0);                                // tt_isdst (standard time)
-  s.push_back(0);                                // tt_desigidx ("EST\0")
-  s.append("EST\0", 4);                          // string table
+  append64(unix_time);   // unix_time
+  s.push_back(0);        // type index for transition
+  append32(-18000);      // tt_utoff (-5 hours)
+  s.push_back(0);        // tt_isdst (standard time)
+  s.push_back(0);        // tt_desigidx ("EST\0")
+  s.append("EST\0", 4);  // string table
 
   // POSIX footer
   s.append("\nEST5EDT,M3.2.0,M11.1.0\n");
@@ -997,36 +1015,41 @@ std::unique_ptr<ZoneInfoSource> NegativeEpochTestFactory(
     const std::function<std::unique_ptr<ZoneInfoSource>(const std::string&)>&
         fallback) {
   if (name == "test:negative_epoch_dst") {
+    // 1900-01-01T00:00:00Z (-2208988800) is in negative epoch, but extending
+    // 401 years reaches 2301 AD in the positive unix_time space.
     return std::unique_ptr<ZoneInfoSource>(
-        new StringZoneInfoSource(MakeNegativeEpochTzif()));
+        new StringZoneInfoSource(MakeNegativeEpochTzif(-2208988800LL)));
+  }
+  if (name == "test:negative_epoch_dst_too_far") {
+    // Year -1201 (-100000000000) is so far in the negative epoch that extending
+    // 401 years still leaves the last transition before 1970 (<0).
+    return std::unique_ptr<ZoneInfoSource>(
+        new StringZoneInfoSource(MakeNegativeEpochTzif(-100000000000LL)));
   }
   return fallback(name);
 }
 
 // Tests loading a TZif file whose explicit transitions end in negative epoch
-// with a POSIX DST footer string. Verifies that querying far-future time_points
-// does not cause signed integer overflow, and that lookups for modern dates use
-// the correct POSIX DST transition rules.
+// with a POSIX DST footer string.
 TEST(TimeZoneEdgeCase, NegativeEpochExtended) {
   auto prev_factory = cctz_extension::zone_info_source_factory;
   cctz_extension::zone_info_source_factory = NegativeEpochTestFactory;
   time_zone tz;
   ASSERT_TRUE(load_time_zone("test:negative_epoch_dst", &tz));
-  cctz_extension::zone_info_source_factory = prev_factory;
-
-  // Far-future lookup must not trigger signed integer overflow.
-  // A sanitizer like UBSAN may flag the following line on overflow.
-  static_cast<void>(tz.lookup(time_point<seconds>::max()));
 
   // Summer (July) must use the POSIX DST rule (EDT, UTC-4).
   auto tp_july = convert(civil_second(2026, 7, 20, 12, 0, 0), tz);
   ExpectTime(tp_july, tz, 2026, 7, 20, 12, 0, 0, -4 * 3600, true, "EDT");
-  EXPECT_EQ("EDT", std::string(tz.lookup(tp_july).abbr));
+  EXPECT_STREQ("EDT", tz.lookup(tp_july).abbr);
 
   // Winter (January) must use EST (UTC-5).
   auto tp_jan = convert(civil_second(2026, 1, 20, 12, 0, 0), tz);
   ExpectTime(tp_jan, tz, 2026, 1, 20, 12, 0, 0, -5 * 3600, false, "EST");
-  EXPECT_EQ("EST", std::string(tz.lookup(tp_jan).abbr));
+  EXPECT_STREQ("EST", tz.lookup(tp_jan).abbr);
+
+  // Extended zones that do not reach non-negative unix_time are rejected.
+  EXPECT_FALSE(load_time_zone("test:negative_epoch_dst_too_far", &tz));
+  cctz_extension::zone_info_source_factory = prev_factory;
 }
 
 }  // namespace cctz


### PR DESCRIPTION
When a TZif file has explicit transitions ending before the epoch and
includes a POSIX DST footer string, ExtendTransitions() sets extended_ = true
and generates 401 years of transitions. Load() previously checked
`if (last.unix_time < 0)` unconditionally and appended a static sentinel
transition at unix_time = 2147483647 (2038).
  
Appending a static transition to an extended zone table is incompatible with
the 400-year cycle shifting used for future lookups.
  
This change:
   - Updates TimeZoneInfo::Load() to reject zoneinfo files if 401 years of
     extended transitions fail to reach the non-negative unix time space
     (`if (extended_) return false;`). All valid zoneinfo files easily meet
     this requirement.
   - Avoids appending a static no-op transition when extended_ is true,
     preserving the generated 400-year cycle transition table.
   - Guarantees that for any successfully loaded extended zone, `last.unix_time`
     and `last_year_` are non-negative, ensuring that 400-year cycle calculations
     in BreakTime() and MakeTime() operate safely within bounds.
   - Adds unit test coverage in `time_zone_lookup_test.cc` to verify lookups for
     valid zones with transitions before the epoch, and to confirm rejection of
     zones whose extended transitions fail to reach non-negative unix time.
