### PR TITLE
Avoid signed overflow in TimeZoneInfo::BreakTime()

### DIFF
--- a/src/time_zone_info.cc
+++ b/src/time_zone_info.cc
@@ -963,11 +963,14 @@ time_zone::absolute_lookup TimeZoneInfo::BreakTime(
     // future_spec_, shift back to a supported year using the 400-year
     // cycle of calendaric equivalence and then compensate accordingly.
     if (extended_) {
-      const std::int_fast64_t diff =
-          unix_time - transitions_[timecnt - 1].unix_time;
+      const std::int_fast64_t last_time = transitions_[timecnt - 1].unix_time;
+      const std::int_fast64_t diff = unix_time - last_time;
       const year_t shift = diff / kSecsPer400Years + 1;
-      const auto d = seconds(shift * kSecsPer400Years);
-      time_zone::absolute_lookup al = BreakTime(tp - d);
+      // shift * kSecsPer400Years can be beyond the int64 range, so derive
+      // the shifted time from the remainder rather than the product.
+      const std::int_fast64_t shifted =
+          last_time - kSecsPer400Years + diff % kSecsPer400Years;
+      time_zone::absolute_lookup al = BreakTime(FromUnixSeconds(shifted));
       al.cs = YearShift(al.cs, shift * 400);
       return al;
     }


### PR DESCRIPTION
BreakTime() maps a time past the last transition of an extended zone back into the supported range by computing a 400-year shift and then multiplying it back out as seconds(shift * kSecsPer400Years). A TZif whose transitions are all negative gets the 2147483647 sentinel appended at the end of Load(), so last_time sits near 2.1e9; looking up a time close to the int64 maximum then makes shift 730692562 and the product 9223372042316409600, past INT64_MAX. UBSan flags both the multiply and the tp - d that follows it. cctz::parse() reaches the same sink on ordinary input, since it looks up time_point<seconds>::max() for its range check.

The shifted time is last_time + diff % kSecsPer400Years - kSecsPer400Years, which is the value the subtraction was after and always stays inside the int64 range, so the product never has to be formed. TimeLocal() already bounds its own shift * kSecsPer400Years, and keeping the arithmetic here means callers of lookup() don't have to know which instants are safe to ask about. Results for the bundled zoneinfo are unchanged and the existing tests pass.