### PR TITLE
reject path traversal in FuchsiaZoneInfoSource::Open

### DIFF
--- a/src/time_zone_info.cc
+++ b/src/time_zone_info.cc
@@ -572,6 +572,11 @@ std::unique_ptr<ZoneInfoSource> FuchsiaZoneInfoSource::Open(
   // Use of the "file:" prefix is intended for testing purposes only.
   const std::size_t pos = (name.compare(0, 5, "file:") == 0) ? 5 : 0;
 
+  // Reject unsafe paths (e.g., "../../etc/passwd").
+  if (UnsafePath(name, pos)) {
+    return nullptr;
+  }
+
   // Prefixes where a Fuchsia component might find zoneinfo files,
   // in descending order of preference.
   const auto kTzdataPrefixes = {


### PR DESCRIPTION
FileZoneInfoSource::Open rejects a zone name containing ".." through UnsafePath before it builds a path, but FuchsiaZoneInfoSource::Open concatenates the same untrusted name under its tzdata prefixes and passes the result straight to FOpen with no such check. On a host where one of the Fuchsia prefixes exists, a name like "../../../etc/passwd" resolves out of the tzdata root, and since FOpen only gates on S_ISREG it opens any regular file the process can read. The file loaders guard does not help here because load_time_zone falls through to the Fuchsia loader once the file loader has rejected the name.

Add the UnsafePath check right after the "file:" prefix is stripped, matching FileZoneInfoSource. Keeping the rejection where the name turns into a path means both loaders enforce it the same way, and valid zone names are unaffected.