### PR TITLE
Avoid signed overflow in AndroidZoneInfoSource::Open offset math

### DIFF
--- a/src/time_zone_info.cc
+++ b/src/time_zone_info.cc
@@ -533,7 +533,8 @@ std::unique_ptr<ZoneInfoSource> AndroidZoneInfoSource::Open(
     if (zonecnt * sizeof(ebuf) != index_size) continue;
     for (std::size_t i = 0; i != zonecnt; ++i) {
       if (fread(ebuf, 1, sizeof(ebuf), fp.get()) != sizeof(ebuf)) break;
-      const std::int_fast32_t start = data_offset + Decode32(ebuf + 40);
+      const std::int_fast64_t start =
+          std::int_fast64_t{data_offset} + Decode32(ebuf + 40);
       const std::int_fast32_t length = Decode32(ebuf + 44);
       if (start < 0 || length < 0) break;
       ebuf[40] = '\0';  // ensure zone name is NUL terminated


### PR DESCRIPTION
AndroidZoneInfoSource::Open() computes a zone's file position as data_offset + Decode32(ebuf + 40), where both operands are int_fast32_t values pulled straight from the tzdata index. On a build where int_fast32_t is a 32-bit type (32-bit Android/ARM), two near-INT_MAX index values sum past the type's range, so the addition is signed overflow before the start < 0 guard on the next line ever runs. UBSan on a crafted tzdata blob reports "signed integer overflow: 76 + 2147483647 cannot be represented in type int" right at that add.

Widen the left operand to int_fast64_t so the sum is formed in a type that holds it, which leaves the existing start < 0 / length < 0 rejection meaningful and the later static_cast<long>(start) for fseek unchanged. Doing the widening at the add keeps the fix inside the decode where the operand widths are still in view.