### PR TITLE
avoid signed overflow computing 400-year shift in BreakTime

### DIFF
--- a/src/time_zone_info.cc
+++ b/src/time_zone_info.cc
@@ -975,7 +975,11 @@ time_zone::absolute_lookup TimeZoneInfo::BreakTime(
     if (extended_) {
       const std::int_fast64_t diff =
           unix_time - transitions_[timecnt - 1].unix_time;
-      const year_t shift = diff / kSecsPer400Years + 1;
+      // Bound the number of 400-year cycles so that shift * kSecsPer400Years
+      // stays representable (mirrors the clamp in TimeLocal()). A cycle spans
+      // exactly 400 years, so the recursive call folds in any residual shift.
+      const year_t shift = std::min<year_t>(
+          diff / kSecsPer400Years + 1, seconds::max().count() / kSecsPer400Years);
       const auto d = seconds(shift * kSecsPer400Years);
       time_zone::absolute_lookup al = BreakTime(tp - d);
       al.cs = YearShift(al.cs, shift * 400);

--- a/src/time_zone_info.cc
+++ b/src/time_zone_info.cc
@@ -342,6 +342,14 @@ bool TimeZoneInfo::ExtendTransitions() {
     return EquivTransitions(transitions_.back().type_index, dst_ti);
   }
 
+  // We require that zoneinfo data with a rule for future transitions
+  // ends with a non-negative transition.  This removes the need to add
+  // any "second-half" transition to ensure differences between adjacent
+  // transitions are always representable, while also guaranteeing that
+  // the arithmetic used to shift between 400-year cycles never overflows.
+  // All valid zones easily meet this requirement.
+  if (transitions_.back().unix_time < 0) return false;
+
   // Extend the transitions for an additional 401 years using the future
   // specification. Years beyond those can be handled by mapping back to
   // a cycle-equivalent year within that range. Note that we need 401
@@ -850,7 +858,7 @@ bool TimeZoneInfo::Load(ZoneInfoSource* zip) {
   // previous transition is always representable, without overflow.
   const Transition& last(transitions_.back());
   if (last.unix_time < 0) {
-    if (extended_) return false;
+    assert(!extended_);
     const std::uint_fast8_t type_index = last.type_index;
     Transition& tr(*transitions_.emplace(transitions_.end()));
     tr.unix_time = 2147483647;  // 2038-01-19T03:14:07+00:00
@@ -975,11 +983,7 @@ time_zone::absolute_lookup TimeZoneInfo::BreakTime(
     if (extended_) {
       const std::int_fast64_t diff =
           unix_time - transitions_[timecnt - 1].unix_time;
-      // Bound the number of 400-year cycles so that shift * kSecsPer400Years
-      // stays representable (mirrors the clamp in TimeLocal()). A cycle spans
-      // exactly 400 years, so the recursive call folds in any residual shift.
-      const year_t shift = std::min<year_t>(
-          diff / kSecsPer400Years + 1, seconds::max().count() / kSecsPer400Years);
+      const year_t shift = diff / kSecsPer400Years + 1;
       const auto d = seconds(shift * kSecsPer400Years);
       time_zone::absolute_lookup al = BreakTime(tp - d);
       al.cs = YearShift(al.cs, shift * 400);

--- a/src/time_zone_lookup_test.cc
+++ b/src/time_zone_lookup_test.cc
@@ -1044,6 +1044,14 @@ std::unique_ptr<ZoneInfoSource> ExtendedTestFactory(
         MakeExtendedTzif(-100000000000LL, -5 * 3600, "EST",
                          "EST5EDT,M3.2.0,M11.1.0")));
   }
+  if (name == "test:extended_dst_far_future") {
+    // 1700-01-01T00:00:00Z (-8520336000) extends 401 years to 2101, so the
+    // last transition sits low enough in positive unix time that a lookup at
+    // the maximum time needs a very large 400-year shift in BreakTime().
+    return std::unique_ptr<ZoneInfoSource>(new StringZoneInfoSource(
+        MakeExtendedTzif(-8520336000LL, -5 * 3600, "EST",
+                         "EST5EDT,M3.2.0,M11.1.0")));
+  }
   return fallback(name);
 }
 
@@ -1068,6 +1076,25 @@ TEST(TimeZoneEdgeCase, ExtendedBeforeEpoch) {
 
   // Extended zones that do not reach non-negative unix time are rejected.
   EXPECT_FALSE(load_time_zone("test:extended_dst_too_far", &tz));
+
+  cctz_extension::zone_info_source_factory = prev_factory;
+}
+
+// Looking up the maximum time in an extended zone must fold back through the
+// 400-year cycle without overflowing when BreakTime() computes the shift.
+TEST(TimeZoneEdgeCase, ExtendedFarFuture) {
+  auto prev_factory = cctz_extension::zone_info_source_factory;
+  cctz_extension::zone_info_source_factory = ExtendedTestFactory;
+
+  time_zone tz;
+  ASSERT_TRUE(load_time_zone("test:extended_dst_far_future", &tz));
+
+  // The maximum representable instant lands in December, which the future
+  // rule (EST5EDT,M3.2.0,M11.1.0) resolves to standard time.
+  const auto al = tz.lookup(time_point<cctz::seconds>::max());
+  EXPECT_EQ(-5 * 3600, al.offset);
+  EXPECT_FALSE(al.is_dst);
+  EXPECT_STREQ("EST", al.abbr);
 
   cctz_extension::zone_info_source_factory = prev_factory;
 }

--- a/src/time_zone_lookup_test.cc
+++ b/src/time_zone_lookup_test.cc
@@ -1030,27 +1030,18 @@ std::unique_ptr<ZoneInfoSource> ExtendedTestFactory(
     const std::string& name,
     const std::function<std::unique_ptr<ZoneInfoSource>(const std::string&)>&
         fallback) {
-  if (name == "test:extended_dst") {
-    // 1900-01-01T00:00:00Z (-2208988800) is before epoch, so the zone is
-    // rejected even though extending 401 years would reach 2301 AD in the
-    // positive unix time space.
+  if (name == "test:ExtendedBeforeEpoch") {
+    // -1 (1969-12-31T23:59:59Z) is the latest final transition before the
+    // epoch, so the zone is rejected despite the future specification.
     return std::unique_ptr<ZoneInfoSource>(new StringZoneInfoSource(
-        MakeExtendedTzif(-2208988800LL, -5 * 3600, "EST",
-                         "EST5EDT,M3.2.0,M11.1.0")));
+        MakeExtendedTzif(-1, -5 * 3600, "EST", "EST5EDT,M3.2.0,M11.1.0")));
   }
-  if (name == "test:extended_dst_too_far") {
-    // Year -1201 (-100000000000) is so far before epoch that even extending
-    // 401 years would leave the last transition in the negative unix time space.
-    return std::unique_ptr<ZoneInfoSource>(new StringZoneInfoSource(
-        MakeExtendedTzif(-100000000000LL, -5 * 3600, "EST",
-                         "EST5EDT,M3.2.0,M11.1.0")));
-  }
-  if (name == "test:extended_dst_far_future") {
-    // 1970-01-01T00:00:00Z (0) is the earliest final transition an extended
+  if (name == "test:ExtendedFarFuture") {
+    // 0 (1970-01-01T00:00:00Z) is the earliest final transition an extended
     // zone may have, which maximizes the 400-year shift that BreakTime()
     // needs for a lookup at the maximum time.
     return std::unique_ptr<ZoneInfoSource>(new StringZoneInfoSource(
-        MakeExtendedTzif(0LL, -5 * 3600, "EST", "EST5EDT,M3.2.0,M11.1.0")));
+        MakeExtendedTzif(0, -5 * 3600, "EST", "EST5EDT,M3.2.0,M11.1.0")));
   }
   return fallback(name);
 }
@@ -1061,11 +1052,9 @@ TEST(TimeZoneEdgeCase, ExtendedBeforeEpoch) {
   auto prev_factory = cctz_extension::zone_info_source_factory;
   cctz_extension::zone_info_source_factory = ExtendedTestFactory;
 
-  // Extended zones must end with a non-negative explicit transition,
-  // whether or not extending would reach positive unix time.
+  // Extended zones must end with a non-negative explicit transition.
   time_zone tz;
-  EXPECT_FALSE(load_time_zone("test:extended_dst", &tz));
-  EXPECT_FALSE(load_time_zone("test:extended_dst_too_far", &tz));
+  EXPECT_FALSE(load_time_zone("test:ExtendedBeforeEpoch", &tz));
 
   cctz_extension::zone_info_source_factory = prev_factory;
 }
@@ -1077,7 +1066,7 @@ TEST(TimeZoneEdgeCase, ExtendedFarFuture) {
   cctz_extension::zone_info_source_factory = ExtendedTestFactory;
 
   time_zone tz;
-  ASSERT_TRUE(load_time_zone("test:extended_dst_far_future", &tz));
+  ASSERT_TRUE(load_time_zone("test:ExtendedFarFuture", &tz));
 
   auto tp_max = time_point<cctz::seconds>::max();
   ExpectTime(tp_max, tz, 292277026596, 12, 4, 10, 30, 7, -5 * 3600, false,

--- a/src/time_zone_lookup_test.cc
+++ b/src/time_zone_lookup_test.cc
@@ -1031,50 +1031,40 @@ std::unique_ptr<ZoneInfoSource> ExtendedTestFactory(
     const std::function<std::unique_ptr<ZoneInfoSource>(const std::string&)>&
         fallback) {
   if (name == "test:extended_dst") {
-    // 1900-01-01T00:00:00Z (-2208988800) is before epoch, but extending
-    // 401 years reaches 2301 AD in the positive unix time space.
+    // 1900-01-01T00:00:00Z (-2208988800) is before epoch, so the zone is
+    // rejected even though extending 401 years would reach 2301 AD in the
+    // positive unix time space.
     return std::unique_ptr<ZoneInfoSource>(new StringZoneInfoSource(
         MakeExtendedTzif(-2208988800LL, -5 * 3600, "EST",
                          "EST5EDT,M3.2.0,M11.1.0")));
   }
   if (name == "test:extended_dst_too_far") {
-    // Year -1201 (-100000000000) is so far before epoch that extending
-    // 401 years still leaves the last transition in the negative unix time space.
+    // Year -1201 (-100000000000) is so far before epoch that even extending
+    // 401 years would leave the last transition in the negative unix time space.
     return std::unique_ptr<ZoneInfoSource>(new StringZoneInfoSource(
         MakeExtendedTzif(-100000000000LL, -5 * 3600, "EST",
                          "EST5EDT,M3.2.0,M11.1.0")));
   }
   if (name == "test:extended_dst_far_future") {
-    // 1700-01-01T00:00:00Z (-8520336000) extends 401 years to 2101, so the
-    // last transition sits low enough in positive unix time that a lookup at
-    // the maximum time needs a very large 400-year shift in BreakTime().
+    // 1970-01-01T00:00:00Z (0) is the earliest final transition an extended
+    // zone may have, which maximizes the 400-year shift that BreakTime()
+    // needs for a lookup at the maximum time.
     return std::unique_ptr<ZoneInfoSource>(new StringZoneInfoSource(
-        MakeExtendedTzif(-8520336000LL, -5 * 3600, "EST",
-                         "EST5EDT,M3.2.0,M11.1.0")));
+        MakeExtendedTzif(0LL, -5 * 3600, "EST", "EST5EDT,M3.2.0,M11.1.0")));
   }
   return fallback(name);
 }
 
-// Tests loading a TZif file whose explicit transitions end before epoch
-// with a POSIX DST footer string.
+// Tests that a TZif file whose explicit transitions end before epoch
+// is rejected when it has a POSIX DST footer string.
 TEST(TimeZoneEdgeCase, ExtendedBeforeEpoch) {
   auto prev_factory = cctz_extension::zone_info_source_factory;
   cctz_extension::zone_info_source_factory = ExtendedTestFactory;
 
+  // Extended zones must end with a non-negative explicit transition,
+  // whether or not extending would reach positive unix time.
   time_zone tz;
-  ASSERT_TRUE(load_time_zone("test:extended_dst", &tz));
-
-  // July matches the future rule for EDT (UTC-4).
-  auto tp_july = convert(civil_second(2026, 7, 20, 12, 0, 0), tz);
-  ExpectTime(tp_july, tz, 2026, 7, 20, 12, 0, 0, -4 * 3600, true, "EDT");
-  EXPECT_STREQ("EDT", tz.lookup(tp_july).abbr);
-
-  // January matches the future rule for EST (UTC-5).
-  auto tp_jan = convert(civil_second(2026, 1, 20, 12, 0, 0), tz);
-  ExpectTime(tp_jan, tz, 2026, 1, 20, 12, 0, 0, -5 * 3600, false, "EST");
-  EXPECT_STREQ("EST", tz.lookup(tp_jan).abbr);
-
-  // Extended zones that do not reach non-negative unix time are rejected.
+  EXPECT_FALSE(load_time_zone("test:extended_dst", &tz));
   EXPECT_FALSE(load_time_zone("test:extended_dst_too_far", &tz));
 
   cctz_extension::zone_info_source_factory = prev_factory;
@@ -1089,12 +1079,10 @@ TEST(TimeZoneEdgeCase, ExtendedFarFuture) {
   time_zone tz;
   ASSERT_TRUE(load_time_zone("test:extended_dst_far_future", &tz));
 
-  // The maximum representable instant lands in December, which the future
-  // rule (EST5EDT,M3.2.0,M11.1.0) resolves to standard time.
-  const auto al = tz.lookup(time_point<cctz::seconds>::max());
-  EXPECT_EQ(-5 * 3600, al.offset);
-  EXPECT_FALSE(al.is_dst);
-  EXPECT_STREQ("EST", al.abbr);
+  auto tp_max = time_point<cctz::seconds>::max();
+  ExpectTime(tp_max, tz, 292277026596, 12, 4, 10, 30, 7, -5 * 3600, false,
+             "EST");
+  EXPECT_STREQ("EST", tz.lookup(tp_max).abbr);
 
   cctz_extension::zone_info_source_factory = prev_factory;
 }


### PR DESCRIPTION
BreakTime()'s extended-zone branch shifts a far-future time back through the 400-year cycle with `shift = diff / kSecsPer400Years + 1`, then forms `seconds(shift * kSecsPer400Years)` in signed int64. When a zone is extended by a POSIX DST footer and its last transition sits low in positive unix time (explicit transitions before ~1795, e.g. a 1700 transition that extends to 2101), a lookup near `time_point<seconds>::max()` drives shift past `seconds::max()/kSecsPer400Years` and that multiply overflows. UBSan trips at time_zone_info.cc:979 on `730692562 * 12622780800`.

Per review, this now extends the restriction from #357 instead of clamping in BreakTime(): zoneinfo data with a rule for future transitions must end its explicit transitions at or after the epoch, so the 400-year cycle starts in non-negative unix time and `(diff / kSecsPer400Years + 1) * kSecsPer400Years` is always representable. The #357 check in Load() becomes an assert, before-epoch extended zones are rejected outright, and the far-future test looks up the maximum time in a zone whose final transition is at the epoch, the largest permitted shift.