### PR TITLE
reject unterminated abbreviations in TimeZoneInfo::Load

### DIFF
--- a/src/time_zone_info.cc
+++ b/src/time_zone_info.cc
@@ -802,8 +802,9 @@ bool TimeZoneInfo::Load(ZoneInfoSource* zip) {
   // Copy all the abbreviations. The area holds NUL-terminated strings, and
   // LocalTime() hands out a pointer into it, so the final abbreviation has
   // to be terminated within the area itself. Otherwise an abbreviation runs
-  // on into whatever ExtendTransitions() later appends.
-  if (hdr.charcnt == 0 || bp[hdr.charcnt - 1] != '\0')
+  // on into whatever ExtendTransitions() later appends. (hdr.charcnt != 0
+  // because every abbr_index was validated to be less than it.)
+  if (bp[hdr.charcnt - 1] != '\0')
     return false;
   abbreviations_.reserve(hdr.charcnt + 10);
   abbreviations_.assign(bp, hdr.charcnt);

--- a/src/time_zone_info.cc
+++ b/src/time_zone_info.cc
@@ -799,7 +799,12 @@ bool TimeZoneInfo::Load(ZoneInfoSource* zip) {
       default_transition_type_ = static_cast<std::uint_fast8_t>(index);
   }
 
-  // Copy all the abbreviations.
+  // Copy all the abbreviations. The area holds NUL-terminated strings, and
+  // LocalTime() hands out a pointer into it, so the final abbreviation has
+  // to be terminated within the area itself. Otherwise an abbreviation runs
+  // on into whatever ExtendTransitions() later appends.
+  if (hdr.charcnt == 0 || bp[hdr.charcnt - 1] != '\0')
+    return false;
   abbreviations_.reserve(hdr.charcnt + 10);
   abbreviations_.assign(bp, hdr.charcnt);
   bp += hdr.charcnt;

--- a/src/time_zone_lookup_test.cc
+++ b/src/time_zone_lookup_test.cc
@@ -1047,33 +1047,23 @@ std::unique_ptr<ZoneInfoSource> ExtendedTestFactory(
         MakeExtendedTzif(0, -5 * 3600, std::string{"EST", 4},
                          "EST5EDT,M3.2.0,M11.1.0")));
   }
-  if (name == "test:terminated_abbr") {
-    return std::unique_ptr<ZoneInfoSource>(new StringZoneInfoSource(
-        MakeExtendedTzif(0, -5 * 3600, std::string{"EST", 4},
-                         "EST5EDT,M3.2.0,M11.1.0")));
-  }
-  if (name == "test:unterminated_abbr") {
+  if (name == "test:UnterminatedAbbreviation") {
+    // The abbreviation area is missing its final NUL, so the abbreviation
+    // would run into whatever ExtendTransitions() appends behind it.
     return std::unique_ptr<ZoneInfoSource>(new StringZoneInfoSource(
         MakeExtendedTzif(0, -5 * 3600, "EST", "EST5EDT,M3.2.0,M11.1.0")));
   }
   return fallback(name);
 }
 
-// Tests loading a TZif file whose abbreviation area is not NUL-terminated.
+// Tests that a TZif file whose abbreviation area is not NUL-terminated
+// is rejected.
 TEST(TimeZoneEdgeCase, UnterminatedAbbreviation) {
   auto prev_factory = cctz_extension::zone_info_source_factory;
   cctz_extension::zone_info_source_factory = ExtendedTestFactory;
 
-  // With the terminator the abbreviation stops where the file says it does.
   time_zone tz;
-  ASSERT_TRUE(load_time_zone("test:terminated_abbr", &tz));
-  auto tp = convert(civil_second(2026, 1, 20, 12, 0, 0), tz);
-  ExpectTime(tp, tz, 2026, 1, 20, 12, 0, 0, -5 * 3600, false, "EST");
-  EXPECT_STREQ("EST", tz.lookup(tp).abbr);
-
-  // Without it the abbreviation would run into the "EDT" that the POSIX
-  // footer appends, so the zone is rejected instead.
-  EXPECT_FALSE(load_time_zone("test:unterminated_abbr", &tz));
+  EXPECT_FALSE(load_time_zone("test:UnterminatedAbbreviation", &tz));
 
   cctz_extension::zone_info_source_factory = prev_factory;
 }

--- a/src/time_zone_lookup_test.cc
+++ b/src/time_zone_lookup_test.cc
@@ -952,7 +952,8 @@ class StringZoneInfoSource : public ZoneInfoSource {
 std::string MakeExtendedTzif(std::int_fast64_t unix_time,
                              std::int_fast32_t utc_offset,
                              const std::string& abbr,
-                             const std::string& future_spec) {
+                             const std::string& future_spec,
+                             bool terminate_abbr = true) {
   std::string s;
   auto append32 = [&s](std::int_fast32_t v) {
     const std::int_fast32_t s32max = 0x7fffffff;
@@ -981,7 +982,8 @@ std::string MakeExtendedTzif(std::int_fast64_t unix_time,
     }
   };
 
-  const std::size_t charcnt = abbr.size() + 1;  // includes the trailing '\0'
+  // Normally includes the trailing '\0', as a valid TZif file must.
+  const std::size_t charcnt = abbr.size() + (terminate_abbr ? 1 : 0);
 
   // 32-bit header
   s.append(TZ_MAGIC, 4);
@@ -1043,7 +1045,35 @@ std::unique_ptr<ZoneInfoSource> ExtendedTestFactory(
     return std::unique_ptr<ZoneInfoSource>(new StringZoneInfoSource(
         MakeExtendedTzif(0, -5 * 3600, "EST", "EST5EDT,M3.2.0,M11.1.0")));
   }
+  if (name == "test:terminated_abbr") {
+    return std::unique_ptr<ZoneInfoSource>(new StringZoneInfoSource(
+        MakeExtendedTzif(0, -5 * 3600, "EST", "EST5EDT,M3.2.0,M11.1.0")));
+  }
+  if (name == "test:unterminated_abbr") {
+    return std::unique_ptr<ZoneInfoSource>(new StringZoneInfoSource(
+        MakeExtendedTzif(0, -5 * 3600, "EST", "EST5EDT,M3.2.0,M11.1.0",
+                         /*terminate_abbr=*/false)));
+  }
   return fallback(name);
+}
+
+// Tests loading a TZif file whose abbreviation area is not NUL-terminated.
+TEST(TimeZoneEdgeCase, UnterminatedAbbreviation) {
+  auto prev_factory = cctz_extension::zone_info_source_factory;
+  cctz_extension::zone_info_source_factory = ExtendedTestFactory;
+
+  // With the terminator the abbreviation stops where the file says it does.
+  time_zone tz;
+  ASSERT_TRUE(load_time_zone("test:terminated_abbr", &tz));
+  auto tp = convert(civil_second(2026, 1, 20, 12, 0, 0), tz);
+  ExpectTime(tp, tz, 2026, 1, 20, 12, 0, 0, -5 * 3600, false, "EST");
+  EXPECT_STREQ("EST", tz.lookup(tp).abbr);
+
+  // Without it the abbreviation would run into the "EDT" that the POSIX
+  // footer appends, so the zone is rejected instead.
+  EXPECT_FALSE(load_time_zone("test:unterminated_abbr", &tz));
+
+  cctz_extension::zone_info_source_factory = prev_factory;
 }
 
 // Tests that a TZif file whose explicit transitions end before epoch

--- a/src/time_zone_lookup_test.cc
+++ b/src/time_zone_lookup_test.cc
@@ -947,13 +947,14 @@ class StringZoneInfoSource : public ZoneInfoSource {
   std::size_t offset_;
 };
 
-// Constructs a minimal valid TZif2 string with a single 64-bit transition
-// at the given transition time and a future POSIX rule.
+// Constructs a minimal TZif2 string with a single 64-bit transition
+// at the given transition time and a future POSIX rule. The abbreviation
+// area holds abbr verbatim, so a valid file's abbr must include the
+// trailing '\0' (e.g., std::string{"EST", 4}).
 std::string MakeExtendedTzif(std::int_fast64_t unix_time,
                              std::int_fast32_t utc_offset,
                              const std::string& abbr,
-                             const std::string& future_spec,
-                             bool terminate_abbr = true) {
+                             const std::string& future_spec) {
   std::string s;
   auto append32 = [&s](std::int_fast32_t v) {
     const std::int_fast32_t s32max = 0x7fffffff;
@@ -982,8 +983,7 @@ std::string MakeExtendedTzif(std::int_fast64_t unix_time,
     }
   };
 
-  // Normally includes the trailing '\0', as a valid TZif file must.
-  const std::size_t charcnt = abbr.size() + (terminate_abbr ? 1 : 0);
+  const std::size_t charcnt = abbr.size();
 
   // 32-bit header
   s.append(TZ_MAGIC, 4);
@@ -1000,7 +1000,7 @@ std::string MakeExtendedTzif(std::int_fast64_t unix_time,
   append32(utc_offset);               // tt_utoff
   s.push_back(0);                     // tt_isdst (standard time)
   s.push_back(0);                     // tt_desigidx
-  s.append(abbr.c_str(), charcnt);    // abbreviation table
+  s.append(abbr);                     // abbreviation table
 
   // 64-bit header
   s.append(TZ_MAGIC, 4);
@@ -1019,7 +1019,7 @@ std::string MakeExtendedTzif(std::int_fast64_t unix_time,
   append32(utc_offset);               // tt_utoff
   s.push_back(0);                     // tt_isdst (standard time)
   s.push_back(0);                     // tt_desigidx
-  s.append(abbr.c_str(), charcnt);  // abbreviation table
+  s.append(abbr);                     // abbreviation table
 
   // POSIX footer
   s.push_back('\n');
@@ -1036,23 +1036,25 @@ std::unique_ptr<ZoneInfoSource> ExtendedTestFactory(
     // -1 (1969-12-31T23:59:59Z) is the latest final transition before the
     // epoch, so the zone is rejected despite the future specification.
     return std::unique_ptr<ZoneInfoSource>(new StringZoneInfoSource(
-        MakeExtendedTzif(-1, -5 * 3600, "EST", "EST5EDT,M3.2.0,M11.1.0")));
+        MakeExtendedTzif(-1, -5 * 3600, std::string{"EST", 4},
+                         "EST5EDT,M3.2.0,M11.1.0")));
   }
   if (name == "test:ExtendedFarFuture") {
     // 0 (1970-01-01T00:00:00Z) is the earliest final transition an extended
     // zone may have, which maximizes the 400-year shift that BreakTime()
     // needs for a lookup at the maximum time.
     return std::unique_ptr<ZoneInfoSource>(new StringZoneInfoSource(
-        MakeExtendedTzif(0, -5 * 3600, "EST", "EST5EDT,M3.2.0,M11.1.0")));
+        MakeExtendedTzif(0, -5 * 3600, std::string{"EST", 4},
+                         "EST5EDT,M3.2.0,M11.1.0")));
   }
   if (name == "test:terminated_abbr") {
     return std::unique_ptr<ZoneInfoSource>(new StringZoneInfoSource(
-        MakeExtendedTzif(0, -5 * 3600, "EST", "EST5EDT,M3.2.0,M11.1.0")));
+        MakeExtendedTzif(0, -5 * 3600, std::string{"EST", 4},
+                         "EST5EDT,M3.2.0,M11.1.0")));
   }
   if (name == "test:unterminated_abbr") {
     return std::unique_ptr<ZoneInfoSource>(new StringZoneInfoSource(
-        MakeExtendedTzif(0, -5 * 3600, "EST", "EST5EDT,M3.2.0,M11.1.0",
-                         /*terminate_abbr=*/false)));
+        MakeExtendedTzif(0, -5 * 3600, "EST", "EST5EDT,M3.2.0,M11.1.0")));
   }
   return fallback(name);
 }


### PR DESCRIPTION
Load() validates every other decoded field but takes the abbreviation area on faith: tzfile.h describes it as "'\0'-terminated zone abbreviations" and abbr_index is checked against charcnt, yet nothing confirms the area itself ends in a NUL. Since LocalTime() hands out a bare `const char*` into `abbreviations_` as `absolute_lookup::abbr`, a zone carrying the three bytes "EST" with an `EST5EDT,M3.2.0,M11.1.0` footer loads fine and `lookup().abbr` comes back "ESTEDT", running on into the abbreviation GetTransitionType() appended behind it. Widening the footer to `EST5<XYZLONGABBREVIATION>` stretches that same lookup to 22 characters.

Reject it in Load(), alongside the existing charcnt and abbr_index checks. Keeping the guarantee on the one buffer every abbr pointer aliases beats asking each reader to bound its own string, and the other producers of that area (GetTransitionType(), ResetToBuiltinUTC()) already append the terminator themselves, so this only covers what comes off disk. All 485 zones under testdata/zoneinfo still load and convert unchanged.
