### PR TITLE
reject NUL as a digit in Parse02d

### DIFF
--- a/src/time_zone_fixed.cc
+++ b/src/time_zone_fixed.cc
@@ -35,12 +35,19 @@ char* Format02d(char* p, int v) {
   return p;
 }
 
+// Returns the value of the decimal digit ch, or -1 if ch is not a digit.
+// Note that std::strchr() also matches kDigits' terminating '\0', which
+// would otherwise be taken for a tenth digit.
+int ParseDigit(char ch) {
+  const char* const dp = std::strchr(kDigits, ch);
+  return (dp == nullptr || *dp == '\0') ? -1 : static_cast<int>(dp - kDigits);
+}
+
 int Parse02d(const char* p) {
-  if (const char* ap = std::strchr(kDigits, *p)) {
-    int v = static_cast<int>(ap - kDigits);
-    if (const char* bp = std::strchr(kDigits, *++p)) {
-      return (v * 10) + static_cast<int>(bp - kDigits);
-    }
+  const int hi = ParseDigit(p[0]);
+  if (hi >= 0) {
+    const int lo = ParseDigit(p[1]);
+    if (lo >= 0) return (hi * 10) + lo;
   }
   return -1;
 }

--- a/src/time_zone_lookup_test.cc
+++ b/src/time_zone_lookup_test.cc
@@ -186,6 +186,13 @@ TEST(TimeZone, Failures) {
   EXPECT_FALSE(load_time_zone("file:/../etc/passwd", &tz));
   EXPECT_FALSE(load_time_zone("file:America/../America/Los_Angeles", &tz));
 
+  // Reject a fixed-offset name with a NUL where a digit belongs.
+  for (const int i : {10, 11, 13, 14, 16, 17}) {
+    std::string name = "Fixed/UTC+00:00:00";
+    name[static_cast<std::size_t>(i)] = '\0';
+    EXPECT_FALSE(load_time_zone(name, &tz)) << "NUL at offset " << i;
+  }
+
   // Reject non-regular files and directories.
   EXPECT_FALSE(load_time_zone("file:/dev/null", &tz));
   EXPECT_FALSE(load_time_zone("file:/dev/stdin", &tz));


### PR DESCRIPTION
Parse02d() identifies digits with `std::strchr(kDigits, *p)`, but strchr() counts the terminating NUL as part of the string, so a `'\0'` byte comes back as a pointer to `kDigits[10]` and parses as the value 10 rather than failing. Zone names reach FixedOffsetFromName() straight from load_time_zone(), and a std::string carries embedded NULs happily: `load_time_zone(std::string("Fixed/UTC+00:\0" "0:00", 18))` returns true and the zone reports a 6000s offset, while `"Fixed/UTC+00:00:0\0"` gives 10s. A NUL at any of offsets 11, 13, 14, 16 or 17 is accepted, so such a name stops round-tripping through FixedOffsetToName().

Move the digit lookup into a helper that excludes the terminator. The other users of this idiom already guard it explicitly with `if (d >= 10) break;` (ParseInt() and ParseSubSeconds() in time_zone_format.cc, ParseInt() and ParseAbbr() in time_zone_posix.cc); Parse02d() was the one left out, and keeping the check inside the lookup covers both digit reads at once. Valid names parse exactly as before, and the 485 zones under testdata/zoneinfo still load unchanged.