### PR TITLE
reject zones whose extended transitions are out of order

### DIFF
--- a/src/time_zone_info.cc
+++ b/src/time_zone_info.cc
@@ -753,11 +753,6 @@ bool TimeZoneInfo::Load(ZoneInfoSource* zip) {
     if (transitions_[i].unix_time < -(1LL << 59) ||
         transitions_[i].unix_time > (1LL << 59))
       return false;  // out of range
-    if (i != 0) {
-      // Check that the transitions are ordered by time (as zic guarantees).
-      if (!Transition::ByUnixTime()(transitions_[i - 1], transitions_[i]))
-        return false;  // out of order
-    }
   }
   bool seen_type_0 = false;
   for (std::size_t i = 0; i != hdr.timecnt; ++i) {
@@ -880,11 +875,13 @@ bool TimeZoneInfo::Load(ZoneInfoSource* zip) {
     ttp = &transition_types_[tr.type_index];
     tr.civil_sec = LocalTime(tr.unix_time, *ttp).cs;
     if (i != 0) {
-      // Check that the transitions are ordered by civil time. Essentially
-      // this means that an offset change cannot cross another such change.
-      // No one does this in practice, and we depend on it in MakeTime().
-      if (!Transition::ByCivilTime()(transitions_[i - 1], tr))
+      // Check that offset changes don't cross each other. No one
+      // does this in practice, and we depend on increasing absolute
+      // and civil times in BreakTime() and MakeTime() respectively.
+      if (!Transition::ByUnixTime()(transitions_[i - 1], tr) ||
+          !Transition::ByCivilTime()(transitions_[i - 1], tr)) {
         return false;  // out of order
+      }
     }
   }
 

--- a/src/time_zone_lookup_test.cc
+++ b/src/time_zone_lookup_test.cc
@@ -1054,6 +1054,14 @@ std::unique_ptr<ZoneInfoSource> ExtendedTestFactory(
         MakeExtendedTzif(0, -5 * 3600, std::string{"EST", 4},
                          "EST5EDT,M3.2.0,M11.1.0")));
   }
+  if (name == "test:ExtendedOverlappingRules") {
+    // The daylight time of one year starts more than four days after its
+    // nominal date, while the next year's ends more than five days before
+    // its own, so the two years' generated transitions overlap.
+    return std::unique_ptr<ZoneInfoSource>(new StringZoneInfoSource(
+        MakeExtendedTzif(0, -5 * 3600, std::string{"STD", 4},
+                         "STD-12:00:00DST12:00:00,358/100:00:00,1/-139:00:00")));
+  }
   if (name == "test:UnterminatedAbbreviation") {
     // The abbreviation area is missing its final NUL, so the abbreviation
     // would run into whatever ExtendTransitions() appends behind it.
@@ -1084,6 +1092,20 @@ TEST(TimeZoneEdgeCase, ExtendedBeforeEpoch) {
   // Extended zones must end with a non-negative explicit transition.
   time_zone tz;
   EXPECT_FALSE(load_time_zone("test:ExtendedBeforeEpoch", &tz));
+
+  cctz_extension::zone_info_source_factory = prev_factory;
+}
+
+// A transition time may include a day offset of up to +/-167 hours, so the
+// rules for consecutive years can overlap, producing transitions that go
+// backward in unix time. BreakTime() binary searches the transitions by
+// unix time, so such a zone must be rejected.
+TEST(TimeZoneEdgeCase, ExtendedOverlappingRules) {
+  auto prev_factory = cctz_extension::zone_info_source_factory;
+  cctz_extension::zone_info_source_factory = ExtendedTestFactory;
+
+  time_zone tz;
+  EXPECT_FALSE(load_time_zone("test:ExtendedOverlappingRules", &tz));
 
   cctz_extension::zone_info_source_factory = prev_factory;
 }


### PR DESCRIPTION
ExtendTransitions() generates the future transitions a year at a time and guards each generated pair with `last_time`, the unix time of the last transition loaded from the file. That bound never moves as transitions are pushed, so nothing keeps one year's pair ahead of the next year's. A transition time may carry a day offset of up to +/-167 hours, which is more slack than the day or so separating adjacent years, so a footer whose daylight time starts several days after its nominal date while the following year's ends several days before its own leaves transitions_ out of order in unix time. With `STD-12:00:00DST12:00:00,358/100:00:00,1/-139:00:00` (ordinary +/-12h offsets) the same instant 1970-12-27T17:00:00Z resolves to offset 43200 or -18000 on the same time_zone, depending only on which instant was looked up before it.

No real zone loops civil times back on themselves this way, so reject such rules and fail the load: fold the unix-time ordering check into the loop that already checks the civil-time ordering of every transition, which covers the extended transitions as well as the loaded ones. Every zone in testdata/zoneinfo still loads.