### PR TITLE
reject an empty quoted abbreviation in ParseAbbr

### DIFF
--- a/src/time_zone_posix.cc
+++ b/src/time_zone_posix.cc
@@ -42,13 +42,14 @@ const char* ParseInt(const char* p, int min, int max, int* vp) {
   return p;
 }
 
-// abbr = <.*?> | [^-+,\d]{3,}
+// abbr = <.+?> | [^-+,\d]{3,}
 const char* ParseAbbr(const char* p, std::string* abbr) {
   const char* op = p;
   if (*p == '<') {  // special zoneinfo <...> form
     while (*++p != '>') {
       if (*p == '\0') return nullptr;
     }
+    if (p - op < 2) return nullptr;  // no "<>"
     abbr->assign(op + 1, static_cast<std::size_t>(p - op) - 1);
     return ++p;
   }

--- a/src/time_zone_posix.cc
+++ b/src/time_zone_posix.cc
@@ -46,10 +46,10 @@ const char* ParseInt(const char* p, int min, int max, int* vp) {
 const char* ParseAbbr(const char* p, std::string* abbr) {
   const char* op = p;
   if (*p == '<') {  // special zoneinfo <...> form
+    if (*++p == '>' || *p == '\0') return nullptr;  // no "<>"
     while (*++p != '>') {
       if (*p == '\0') return nullptr;
     }
-    if (p - op < 2) return nullptr;  // no "<>"
     abbr->assign(op + 1, static_cast<std::size_t>(p - op) - 1);
     return ++p;
   }

--- a/src/time_zone_posix_test.cc
+++ b/src/time_zone_posix_test.cc
@@ -29,7 +29,7 @@ using ::testing::IsEmpty;
 // them).  So, ...
 //
 //   spec = abbr offset [ abbr [ offset ] datetime datetime ]
-//   abbr = <.*?> | [^-+,\d]{3,}
+//   abbr = <.+?> | [^-+,\d]{3,}
 //   offset = [+|-]hh[:mm[:ss]]
 //   datetime = , ( Jn | n | Mm.w.d ) [ / offset ]
 
@@ -138,6 +138,7 @@ TEST(TimeZonePosix, ParseErrors) {
   EXPECT_FALSE(ParsePosixSpec("ET-", &zone));
   EXPECT_FALSE(ParsePosixSpec("ET,", &zone));
   EXPECT_FALSE(ParsePosixSpec("<00", &zone));
+  EXPECT_FALSE(ParsePosixSpec("<>0", &zone));
 
   // STD offset errors.
   EXPECT_FALSE(ParsePosixSpec("<00>", &zone));
@@ -150,6 +151,7 @@ TEST(TimeZonePosix, ParseErrors) {
   EXPECT_FALSE(ParsePosixSpec("EST5EDT+,M3.2.0,M11.1.0", &zone));
   EXPECT_FALSE(ParsePosixSpec("EST5EDT-,M3.2.0,M11.1.0", &zone));
   EXPECT_FALSE(ParsePosixSpec("<00>0<-01", &zone));
+  EXPECT_FALSE(ParsePosixSpec("EST5<>,M3.2.0,M11.1.0", &zone));
 
   // DST offset errors.
   EXPECT_FALSE(ParsePosixSpec("<01>1<00>?,0,0", &zone));

--- a/src/time_zone_posix_test.cc
+++ b/src/time_zone_posix_test.cc
@@ -137,6 +137,7 @@ TEST(TimeZonePosix, ParseErrors) {
   EXPECT_FALSE(ParsePosixSpec("ET+", &zone));
   EXPECT_FALSE(ParsePosixSpec("ET-", &zone));
   EXPECT_FALSE(ParsePosixSpec("ET,", &zone));
+  EXPECT_FALSE(ParsePosixSpec("<", &zone));
   EXPECT_FALSE(ParsePosixSpec("<00", &zone));
   EXPECT_FALSE(ParsePosixSpec("<>0", &zone));
 


### PR DESCRIPTION
ParseAbbr() bounds the length of the unquoted abbreviation form but not the `<...>` one, so `<>` parses as a zero-length abbreviation. An empty dst_abbr is how PosixTimeZone signals "no daylight time" (time_zone_posix.h, and the `if (posix.dst_abbr.empty())` branch in ExtendTransitions()), so a footer like `EST5<>,M3.2.0,M11.1.0` loads with its DST rule quietly dropped and load_time_zone() still returns true. Looking up 2035-07-01T12:00:00Z gives -18000/EST against 2 transitions, where `EST5EDT,M3.2.0,M11.1.0` gives -14400/EDT against 804; `<>5` does the same to std_abbr and leaves %Z empty.

Add the matching length check to the quoted branch, beside the existing `p - op < 3`, so the constraint lives where the abbreviation is built instead of asking each consumer to treat empty as two different things. tzcode rejects the same input in tzparse() (`if (!stdlen) return false;`) and RFC 9636 wants at least one character between the brackets. No valid zone shifts: all 485 under testdata/zoneinfo give byte-identical descriptions, lookups, offsets and abbreviations before and after.
