### PR TITLE
reject out-of-range minute and second fields in FixedOffsetFromName

### DIFF
--- a/src/time_zone_fixed.cc
+++ b/src/time_zone_fixed.cc
@@ -75,9 +75,9 @@ bool FixedOffsetFromName(const std::string& name, seconds* offset) {
   int hours = Parse02d(np + 1);
   if (hours == -1) return false;
   int mins = Parse02d(np + 4);
-  if (mins == -1) return false;
+  if (mins == -1 || mins > 59) return false;
   int secs = Parse02d(np + 7);
-  if (secs == -1) return false;
+  if (secs == -1 || secs > 59) return false;
 
   secs += ((hours * 60) + mins) * 60;
   if (secs > 24 * 60 * 60) return false;  // outside supported offset range

--- a/src/time_zone_lookup_test.cc
+++ b/src/time_zone_lookup_test.cc
@@ -187,6 +187,14 @@ TEST(TimeZone, Failures) {
     EXPECT_FALSE(load_time_zone(name, &tz)) << "NUL at offset " << i;
   }
 
+  // Reject a fixed-offset name whose minute or second field is out of range,
+  // even when the aggregate offset stays inside the supported 24h span.
+  EXPECT_FALSE(load_time_zone("Fixed/UTC+00:60:00", &tz));
+  EXPECT_FALSE(load_time_zone("Fixed/UTC+00:99:00", &tz));
+  EXPECT_FALSE(load_time_zone("Fixed/UTC+00:00:60", &tz));
+  EXPECT_FALSE(load_time_zone("Fixed/UTC+00:00:99", &tz));
+  EXPECT_FALSE(load_time_zone("Fixed/UTC-00:00:99", &tz));
+
   // Reject path-traversal components.
   EXPECT_FALSE(load_time_zone("file:../etc/passwd", &tz));
   EXPECT_FALSE(load_time_zone("file:../../etc/passwd", &tz));


### PR DESCRIPTION
FixedOffsetFromName parses a Fixed/UTC+hh:mm:ss name but only bounds the aggregate offset against 24h, never the individual minute and second fields. Parse02d returns any two digits, so a name like Fixed/UTC+00:60:00 or Fixed/UTC+00:00:99 loads and reports a shifted offset (+01:00:00 and +00:01:39 here) even though FixedOffsetToName never emits a field past 59. That one-way acceptance breaks the FixedOffsetToName/FixedOffsetFromName round trip the fixed-zone names depend on.

Reject a minute or second field above 59 where it is parsed. The sibling offset parsers (ParseOffset in time_zone_posix.cc and time_zone_format.cc) already clamp each field to 0-59 through ParseInt, so applying the same per-field bound here lines the fixed-name reader up with them and keeps the check next to the value it validates. Valid names, including the +24:00:00 upper bound, load exactly as before.