### PR TITLE
Avoid signed overflow forming sub-second time_points in join_seconds

### DIFF
--- a/include/cctz/time_zone.h
+++ b/include/cctz/time_zone.h
@@ -404,9 +404,20 @@ bool join_seconds(
     const time_point<seconds>& sec, const femtoseconds& fs,
     time_point<std::chrono::duration<Rep, std::ratio<1, Denom>>>* tpp) {
   using D = std::chrono::duration<Rep, std::ratio<1, Denom>>;
-  // TODO(#199): Return false if result unrepresentable as a time_point<D>.
-  *tpp = std::chrono::time_point_cast<D>(sec);
-  *tpp += std::chrono::duration_cast<D>(fs);
+  const auto count = sec.time_since_epoch().count();
+  const auto sub = std::chrono::duration_cast<D>(fs).count();  // in [0, Denom)
+  // The result is count*Denom + sub ticks of D. Reject inputs whose value is
+  // not representable in Rep. Note that count*Denom by itself can exceed Rep
+  // even when count*Denom + sub does not, so the bound and the result are both
+  // computed without forming that intermediate product.
+  const auto qmin = (std::numeric_limits<Rep>::min)() / Denom;
+  const auto rmin = (std::numeric_limits<Rep>::min)() % Denom;
+  if (count > ((std::numeric_limits<Rep>::max)() - sub) / Denom) return false;
+  if (count < (sub - rmin >= Denom ? qmin - 1 : qmin)) return false;
+  const Rep ticks = (count < qmin)
+                        ? static_cast<Rep>(qmin * Denom + (sub - Denom))
+                        : static_cast<Rep>(count * Denom + sub);
+  *tpp = time_point<D>() + D{ticks};
   return true;
 }
 

--- a/src/time_zone_format_test.cc
+++ b/src/time_zone_format_test.cc
@@ -793,6 +793,30 @@ TEST(Parse, TimePointResolution) {
   EXPECT_EQ("03:00:00", cctz::format(kFmt, tp_h, utc));
 }
 
+TEST(Parse, TimePointRange) {
+  const time_zone utc = utc_time_zone();
+
+  // An instant that is representable as a time_point<seconds> but whose value
+  // in a finer resolution would not fit in the destination Rep must be rejected
+  // rather than silently wrapped (forming count*Denom overflowed a signed
+  // 64-bit integer, which is undefined behavior).
+  time_point<chrono::nanoseconds> tp_ns;
+  EXPECT_FALSE(parse("%s", "9223372036854775807", utc, &tp_ns));
+  EXPECT_FALSE(parse("%s", "9223372037", utc, &tp_ns));
+  EXPECT_TRUE(parse("%s", "9223372036", utc, &tp_ns));
+  EXPECT_EQ(chrono::system_clock::from_time_t(9223372036), tp_ns);
+  EXPECT_FALSE(parse("%s", "-9223372037", utc, &tp_ns));
+  EXPECT_TRUE(parse("%s", "-9223372036", utc, &tp_ns));
+  EXPECT_EQ(chrono::system_clock::from_time_t(-9223372036), tp_ns);
+
+  time_point<chrono::microseconds> tp_us;
+  EXPECT_FALSE(parse("%s", "9223372036855", utc, &tp_us));
+  EXPECT_TRUE(parse("%s", "9223372036854", utc, &tp_us));
+  EXPECT_EQ(time_point<chrono::microseconds>() +
+                chrono::microseconds(9223372036854000000),
+            tp_us);
+}
+
 TEST(Parse, TimePointExtendedResolution) {
   const char kFmt[] = "%H:%M:%E*S";
   const time_zone utc = utc_time_zone();


### PR DESCRIPTION
range-check the scaled second count against the destination Rep before forming the value in join_seconds (resolving the TODO for #199), otherwise parsing a large %s into a sub-second time_point such as nanoseconds overflows int64 in the count*Denom of time_point_cast and returns a wrapped instant as a successful parse.