### PR TITLE
Accept a space-padded day of month when parsing %e

### DIFF
--- a/src/time_zone_format.cc
+++ b/src/time_zone_format.cc
@@ -790,8 +790,14 @@ bool parse(const std::string& format, const std::string& input,
         if (data != nullptr) tm.tm_mon -= 1;
         week_num = -1;
         continue;
-      case 'd':
       case 'e':
+        // format() space-pads a single-digit day of the month under %e, so
+        // skip that leading space to keep %e round-tripping through parse().
+        if (*data == ' ') ++data;
+        data = ParseInt(data, 2, 1, 31, &tm.tm_mday);
+        week_num = -1;
+        continue;
+      case 'd':
         data = ParseInt(data, 2, 1, 31, &tm.tm_mday);
         week_num = -1;
         continue;

--- a/src/time_zone_format_test.cc
+++ b/src/time_zone_format_test.cc
@@ -956,6 +956,13 @@ TEST(Parse, PosixConversions) {
   EXPECT_TRUE(parse("%e", "15", tz, &tp));
   EXPECT_EQ(15, convert(tp, tz).day());  // Equivalent to %d
 
+  // format() space-pads a single-digit day of the month under %e, so parse()
+  // accepts that pad, including when the field is not at the start of input.
+  tp = reset;
+  EXPECT_TRUE(parse("%m/%e", "10/ 8", tz, &tp));
+  EXPECT_EQ(10, convert(tp, tz).month());
+  EXPECT_EQ(8, convert(tp, tz).day());
+
   tp = reset;
   EXPECT_TRUE(parse("%H", "17", tz, &tp));
   EXPECT_EQ(17, convert(tp, tz).hour());


### PR DESCRIPTION
format() renders a single-digit day of the month space-padded under %e, so a day of 8 comes out as " 8". The internal %e branch in parse() hands the field straight to ParseInt, which stops on that leading space, and parse() only trims whitespace at the very start of the input. Any %e field that is not first then fails: format("%Y-%m-%e %H:%M:%S", tp) produces "1979-10- 8 00:11:22" and parse() of that same string returns false, with the minimal case being parse("%m/%e", "10/ 8").

Skip the single leading space in the %e branch before ParseInt, which is exactly the pad format() writes and leaves %d and every range check untouched. %e is the only specifier format() space-pads, so the one branch covers the whole round-trip. Added a regression to Parse.PosixConversions.