### PR TITLE
Fix compile error in TimePointOverflow test with libc++

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,7 @@ jobs:
         --test_output=errors
         --test_tag_filters=-benchmark,-fuzztest
 
-  Linux-Clang:
+  Linux-Clang-libstdcxx:
     runs-on: ubuntu-latest
     steps:
 
@@ -96,6 +96,68 @@ jobs:
         --cxxopt=-Wno-undef
         --features=external_include_paths
         --keep_going
+        --repo_env=CC=clang
+        --show_timestamps
+        --test_env="TZDIR=${GITHUB_WORKSPACE}/testdata/zoneinfo"
+        --test_output=errors
+        --test_tag_filters=-benchmark,-fuzztest
+
+  Linux-Clang-libcxx:
+    runs-on: ubuntu-latest
+    steps:
+
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Install libcxx
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libc++1 libc++-dev libc++abi-dev
+
+    - name: Tests
+      run: >
+        bazel test ...
+        --build_tag_filters=-fuzztest
+        --copt=-DGTEST_REMOVE_LEGACY_TEST_CASEAPI_=1
+        --copt=-Werror
+        --cxxopt=-stdlib=libc++
+        --cxxopt=-Wall
+        --cxxopt=-Wextra
+        --cxxopt=-Wc++98-compat-extra-semi
+        --cxxopt=-Wcast-qual
+        --cxxopt=-Wconversion
+        --cxxopt=-Wdeprecated-pragma
+        --cxxopt=-Wfloat-overflow-conversion
+        --cxxopt=-Wfloat-zero-conversion
+        --cxxopt=-Wfor-loop-analysis
+        --cxxopt=-Wformat-security
+        --cxxopt=-Wgnu-redeclared-enum
+        --cxxopt=-Winfinite-recursion
+        --cxxopt=-Winvalid-constexpr
+        --cxxopt=-Wliteral-conversion
+        --cxxopt=-Wmissing-declarations
+        --cxxopt=-Woverlength-strings
+        --cxxopt=-Wpointer-arith
+        --cxxopt=-Wself-assign
+        --cxxopt=-Wshadow-all
+        --cxxopt=-Wshorten-64-to-32
+        --cxxopt=-Wsign-conversion
+        --cxxopt=-Wstring-conversion
+        --cxxopt=-Wtautological-overlap-compare
+        --cxxopt=-Wtautological-unsigned-zero-compare
+        --cxxopt=-Wuninitialized
+        --cxxopt=-Wunreachable-code
+        --cxxopt=-Wunused-comparison
+        --cxxopt=-Wunused-local-typedefs
+        --cxxopt=-Wunused-result
+        --cxxopt=-Wvla
+        --cxxopt=-Wwrite-strings
+        --cxxopt=-Wno-unknown-warning-option
+        --cxxopt=-Wno-undef
+        --features=external_include_paths
+        --keep_going
+        --linkopt=-stdlib=libc++
         --repo_env=CC=clang
         --show_timestamps
         --test_env="TZDIR=${GITHUB_WORKSPACE}/testdata/zoneinfo"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       with:
         fetch-depth: 0
 
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       with:
         fetch-depth: 0
 
@@ -106,7 +106,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       with:
         fetch-depth: 0
 
@@ -168,7 +168,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       with:
         fetch-depth: 0
 
@@ -194,7 +194,7 @@ jobs:
     runs-on: macos-latest
     steps:
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       with:
         fetch-depth: 0
 
@@ -214,7 +214,7 @@ jobs:
     runs-on: windows-latest
     steps:
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       with:
         fetch-depth: 0
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         fetch-depth: 0
 
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         fetch-depth: 0
 
@@ -106,7 +106,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         fetch-depth: 0
 
@@ -168,7 +168,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         fetch-depth: 0
 
@@ -194,7 +194,7 @@ jobs:
     runs-on: macos-latest
     steps:
 
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         fetch-depth: 0
 
@@ -214,7 +214,7 @@ jobs:
     runs-on: windows-latest
     steps:
 
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         fetch-depth: 0
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,11 @@ env:
   BAZEL_CXXOPTS: -std=c++17
   USE_BAZEL_VERSION: 8.5.1
 
+permissions:
+  contents: read
+
 jobs:
+
   Linux-GCC:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,6 +65,7 @@ jobs:
         --build_tag_filters=-fuzztest
         --copt=-DGTEST_REMOVE_LEGACY_TEST_CASEAPI_=1
         --copt=-Werror
+        --cxxopt=-stdlib=libstdc++
         --cxxopt=-Wall
         --cxxopt=-Wextra
         --cxxopt=-Wc++98-compat-extra-semi

--- a/src/time_zone_format_test.cc
+++ b/src/time_zone_format_test.cc
@@ -1669,7 +1669,7 @@ TEST(Parse, TimePointOverflow) {
     // Max time_point<D> is 1970-01-01T02:33:43.372036854775807+00:00.
     EXPECT_TRUE(parse(RFC3339_full,
                       "1970-01-01T02:33:43.3720368547758079+00:00", utc, &tp));
-    EXPECT_EQ(tp, time_point<D>::max());
+    EXPECT_EQ(tp.time_since_epoch(), time_point<D>::max().time_since_epoch());
     EXPECT_EQ("1970-01-01T02:33:43.372036854775807+00:00",
               cctz::format(RFC3339_full, tp, utc));
     // 1 femtosecond beyond max should fail.
@@ -1679,7 +1679,7 @@ TEST(Parse, TimePointOverflow) {
     // Min time_point<D> is 1969-12-31T21:26:16.627963145224192+00:00.
     EXPECT_TRUE(parse(RFC3339_full,
                       "1969-12-31T21:26:16.6279631452241920+00:00", utc, &tp));
-    EXPECT_EQ(tp, time_point<D>::min());
+    EXPECT_EQ(tp.time_since_epoch(), time_point<D>::min().time_since_epoch());
     EXPECT_EQ("1969-12-31T21:26:16.627963145224192+00:00",
               cctz::format(RFC3339_full, tp, utc));
     // 1 femtosecond below min should fail.


### PR DESCRIPTION
GoogleTest's value-printing mechanism checks whether `operator<<` is viable for `std::chrono::sys_time<D>`. In libc++, that overload has the constraint `_Duration{1} < days{1}`. Evaluating `days{1}` in femtoseconds requires converting 86,400 seconds to femtoseconds: 86,400 * 10^15 = 8.64 * 10^19 which exceeds int64_t::max() (~9.22 * 10^18) and causes an integer overflow error during instantiation of `std::chrono::operator<=>`.

Also adds a libc++ build to help catch these issues.