### PR TITLE
Revert change to split_seconds() from #354

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -126,7 +126,7 @@ jobs:
         --build_tag_filters=-fuzztest
         --copt=-DGTEST_REMOVE_LEGACY_TEST_CASEAPI_=1
         --copt=-fsanitize=address,undefined
-        --copt=-fno-sanitize-recover=undefined
+        --copt=-fno-sanitize-recover=all
         --copt=-Werror
         --cxxopt=-stdlib=libc++
         --cxxopt=-Wall

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -165,6 +165,7 @@ jobs:
         --features=external_include_paths
         --keep_going
         --linkopt=-fsanitize=address,undefined
+        --linkopt=-fsanitize-link-c++-runtime
         --linkopt=-stdlib=libc++
         --repo_env=CC=clang
         --show_timestamps

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -125,6 +125,8 @@ jobs:
         bazel test ...
         --build_tag_filters=-fuzztest
         --copt=-DGTEST_REMOVE_LEGACY_TEST_CASEAPI_=1
+        --copt=-fsanitize=address,undefined
+        --copt=-fno-sanitize-recover=undefined
         --copt=-Werror
         --cxxopt=-stdlib=libc++
         --cxxopt=-Wall
@@ -162,6 +164,7 @@ jobs:
         --cxxopt=-Wno-undef
         --features=external_include_paths
         --keep_going
+        --linkopt=-fsanitize=address,undefined
         --linkopt=-stdlib=libc++
         --repo_env=CC=clang
         --show_timestamps

--- a/include/cctz/time_zone.h
+++ b/include/cctz/time_zone.h
@@ -400,7 +400,7 @@ std::pair<time_point<seconds>, D> split_seconds(const time_point<D>& tp) {
   auto sec = std::chrono::time_point_cast<seconds>(tp);
   auto sub = tp - sec;
   // time_point_cast truncates towards zero, so for negative tp with fractional
-  // seconds (e.g., -1.5s), sec is truncated to -1s and sub is negative (-0.5s).
+  // seconds (e.g., -1.5s), sec is truncated (-1s) and sub is negative (-0.5s).
   // Adjust sec and sub so that sec is floored (-2s) and sub is in [0, 1s)
   // (+0.5s).  This adjustment is done after computing sub to avoid overflow
   // when tp is near time_point<D>::min(), where floored sec cannot be converted

--- a/include/cctz/time_zone.h
+++ b/include/cctz/time_zone.h
@@ -399,6 +399,12 @@ template <typename D>
 std::pair<time_point<seconds>, D> split_seconds(const time_point<D>& tp) {
   auto sec = std::chrono::time_point_cast<seconds>(tp);
   auto sub = tp - sec;
+  // time_point_cast truncates towards zero, so for negative tp with fractional
+  // seconds (e.g., -1.5s), sec is truncated to -1s and sub is negative (-0.5s).
+  // Adjust sec and sub so that sec is floored (-2s) and sub is in [0, 1s)
+  // (+0.5s).  This adjustment is done after computing sub to avoid overflow
+  // when tp is near time_point<D>::min(), where floored sec cannot be converted
+  // to D.
   if (sub < D::zero()) {
     sec -= seconds{1};
     sub += seconds{1};

--- a/include/cctz/time_zone.h
+++ b/include/cctz/time_zone.h
@@ -398,8 +398,12 @@ namespace detail {
 template <typename D>
 std::pair<time_point<seconds>, D> split_seconds(const time_point<D>& tp) {
   auto sec = std::chrono::time_point_cast<seconds>(tp);
-  if (sec > tp) sec -= seconds{1};  // TODO(C++17): use std::chrono::floor
-  return {sec, std::chrono::duration_cast<D>(tp - sec)};
+  auto sub = tp - sec;
+  if (sub.count() < 0) {
+    sec -= seconds{1};
+    sub += seconds{1};
+  }
+  return {sec, std::chrono::duration_cast<D>(sub)};
 }
 
 inline std::pair<time_point<seconds>, seconds> split_seconds(

--- a/include/cctz/time_zone.h
+++ b/include/cctz/time_zone.h
@@ -399,7 +399,7 @@ template <typename D>
 std::pair<time_point<seconds>, D> split_seconds(const time_point<D>& tp) {
   auto sec = std::chrono::time_point_cast<seconds>(tp);
   auto sub = tp - sec;
-  if (sub.count() < 0) {
+  if (sub < D::zero()) {
     sec -= seconds{1};
     sub += seconds{1};
   }


### PR DESCRIPTION
In split_seconds(), decrementing `sec` before evaluating `tp - sec` causes `sec` to fall outside the representable range of `time_point<D>` when `tp` is near `time_point<D>::min()`.

For example, with nanosecond resolution, `time_point<D>::min()` is approximately -9,223,372,036.85 seconds. Truncating towards zero with `time_point_cast<seconds>(tp)` yields -9,223,372,036 seconds. Decrementing it to floor the value yields -9,223,372,037 seconds. Evaluating `tp - sec` converts `sec` back to `time_point<D>`, computing: -9,223,372,037 * 1,000,000,000 = -9,223,372,037,000,000,000 ns which overflows int64_t::min() (-9,223,372,036,854,775,808 ns) and triggers a UBSan signed-integer-overflow failure in cctz::format().

Note that even in C++17, calling `std::chrono::floor<seconds>(tp)` and then evaluating `tp - floor` causes this exact same overflow because the floored second cannot be converted to `time_point<D>`.

Fix this by computing `sub = tp - sec` against the truncated `sec` (which is guaranteed to be in range because it is closer to zero than `tp`), and then adjusting `sec` and `sub` independently if `sub.count() < 0`.

Also enable UBSAN in one of the builds to catch this.